### PR TITLE
Update Faraday minimum version dependency

### DIFF
--- a/newgistics.gemspec
+++ b/newgistics.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "virtus", "~> 1.0"
   spec.add_dependency "nokogiri", "~> 1.8"
-  spec.add_dependency "faraday", "~> 0.12"
+  spec.add_dependency "faraday", "~> 0.9"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
#### What's this PR do?
Many other gems depend on earlier versions of Faraday we need to change our minimum version dependency so we can be compatible with them :)