### PR TITLE
Update cassettes to have human-readable responses 

### DIFF
--- a/spec/cassettes/inbound_return/save/failure.yml
+++ b/spec/cassettes/inbound_return/save/failure.yml
@@ -7,14 +7,14 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0"?>
-        <Returns apiKey="3cd9b348dce54548b67758b73c8fa167">
-          <Return id="91755251">
-            <RMA>12938474</RMA>
+        <Returns apiKey="<API_KEY>">
+          <Return id="INVALID">
+            <RMA>RA343167887</RMA>
             <Comments>Sample Comment</Comments>
             <Items>
               <Item>
-                <SKU>BCD-123</SKU>
-                <Qty>2</Qty>
+                <SKU>1007-201-G</SKU>
+                <Qty>1</Qty>
                 <Reason>Too Big</Reason>
               </Item>
             </Items>
@@ -37,22 +37,29 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=nhdnjyzknebiegfxdweszoig; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=wufvkf1fsy4db5nbcu0edeor; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Fri, 25 Aug 2017 16:25:54 GMT
+      - Thu, 07 Sep 2017 13:34:07 GMT
       connection:
       - close
       content-length:
-      - '224'
+      - '214'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxSZXNwb25zZT4NCiAgPFJldHVybnMgLz4NCiAgPFdhcm5pbmdzIC8+DQogIDxFcnJvcnM+DQogICAgPEVycm9yIFJNQT0iMTI5Mzg0NzQiPlVuYWJsZSB0byBjcmVhdGUgaW5ib3VuZCByZXR1cm47IFByb2R1Y3QgU0tVIEJDRC0xMjMgd2FzIG5vdCBmb3VuZDwvRXJyb3I+DQogIDwvRXJyb3JzPg0KPC9SZXNwb25zZT4=
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <Response>
+          <Returns/>
+          <Warnings/>
+          <Errors>
+            <Error RMA="RA343167887">Unable to create inbound return; invalid shipment ID.</Error>
+          </Errors>
+        </Response>
     http_version: 
-  recorded_at: Fri, 25 Aug 2017 16:25:28 GMT
+  recorded_at: Thu, 07 Sep 2017 13:34:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/inbound_return/save/success.yml
+++ b/spec/cassettes/inbound_return/save/success.yml
@@ -7,9 +7,9 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0"?>
-        <Returns apiKey="ABC123">
-          <Return id="91955463">
-            <RMA>RMA_NUMBER</RMA>
+        <Returns apiKey="<API_KEY>">
+          <Return id="91955506">
+            <RMA>RA343167887</RMA>
             <Comments>Sample Comment</Comments>
             <Items>
               <Item>
@@ -28,7 +28,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: 
     headers:
       cache-control:
       - private
@@ -37,22 +37,29 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=0n4w0ojt1ln4ugxws2euhdjh; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=und1duf4rmvcjypy2435szyi; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 05 Sep 2017 15:14:48 GMT
+      - Thu, 07 Sep 2017 13:33:28 GMT
       connection:
       - close
       content-length:
-      - '212'
+      - '213'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxSZXNwb25zZT4NCiAgPFJldHVybnM+DQogICAgPFJldHVybiBJRD0iMTc1NDI1MSIgUk1BPSJSTUFfTlVNQkVSIiBTaGlwbWVudElEPSI5MTk1NTQ2MyIgT3JkZXJJRD0iUjEyMzQ1Njc4OSIgLz4NCiAgPC9SZXR1cm5zPg0KICA8V2FybmluZ3MgLz4NCiAgPEVycm9ycyAvPg0KPC9SZXNwb25zZT4=
-    http_version:
-  recorded_at: Tue, 05 Sep 2017 15:14:48 GMT
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <Response>
+          <Returns>
+            <Return ID="1754253" RMA="RA343167887" ShipmentID="91955506" OrderID="R123456789"/>
+          </Returns>
+          <Warnings/>
+          <Errors/>
+        </Response>
+    http_version: 
+  recorded_at: Thu, 07 Sep 2017 13:33:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/inventory/where/failure.yml
+++ b/spec/cassettes/inventory/where/failure.yml
@@ -12,7 +12,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: 
     headers:
       cache-control:
       - private
@@ -21,22 +21,27 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=suvwrzqkw0d3v0ms0qxoj1vk; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=votj4qa14ljfk40ljka2ranh; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Mon, 28 Aug 2017 20:50:38 GMT
+      - Thu, 07 Sep 2017 13:25:30 GMT
       connection:
       - close
       content-length:
       - '127'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPGVycm9ycz4NCiAgICA8ZXJyb3I+SW52YWxpZCBBUEkga2V5PC9lcnJvcj4NCiAgPC9lcnJvcnM+DQo8L3Jlc3BvbnNlPg==
-    http_version:
-  recorded_at: Mon, 28 Aug 2017 20:50:38 GMT
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <errors>
+            <error>Invalid API key</error>
+          </errors>
+        </response>
+    http_version: 
+  recorded_at: Thu, 07 Sep 2017 13:25:30 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/inventory/where/success.yml
+++ b/spec/cassettes/inventory/where/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://apistaging.newgisticsfulfillment.com/inventory_details.aspx?key=ABC123&sku=SKU
+    uri: https://apistaging.newgisticsfulfillment.com/inventory_details.aspx?key=<API_KEY>&sku=SKU
     body:
       encoding: US-ASCII
       string: ''
@@ -21,21 +21,22 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=k5vz4jmxhi4f3lfm2fytv0u4; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=pvhgcwtrb42yelbdpqihsgt0; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 05 Sep 2017 14:28:28 GMT
+      - Thu, 07 Sep 2017 13:24:29 GMT
       connection:
       - close
       content-length:
       - '45'
     body:
       encoding: ASCII-8BIT
-      string:
+      string: |
+        <?xml version="1.0"?>
         <response>
           <inventories>
             <inventory id="325307271" type="transfer" linkedinventoryid="325307272">
@@ -52,5 +53,5 @@ http_interactions:
           </inventories>
         </response>
     http_version:
-  recorded_at: Tue, 05 Sep 2017 14:28:29 GMT
+  recorded_at: Thu, 07 Sep 2017 13:24:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/order/save/failure.yml
+++ b/spec/cassettes/order/save/failure.yml
@@ -7,10 +7,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0"?>
-        <Orders apiKey="">
-          <Order orderID="XML001">
-            <Warehouse warehouseid="WAREHOUSE_ID"/>
-            <ShipMethod>USPS</ShipMethod>
+        <Orders apiKey="INVALID">
+          <Order orderID="R987654321">
+            <Warehouse warehouseid=""/>
+            <ShipMethod>USPS Express</ShipMethod>
             <InfoLine>Additional order details</InfoLine>
             <RequiresSignature>false</RequiresSignature>
             <IsInsured>false</IsInsured>
@@ -21,15 +21,15 @@ http_interactions:
             <OrderDate>08/20/2017</OrderDate>
             <CustomerInfo>
               <Company/>
-              <FirstName>Stephen</FirstName>
-              <LastName>Strange</LastName>
+              <FirstName>Wade</FirstName>
+              <LastName>Wilson</LastName>
               <Address1>75 Spring St</Address1>
               <Address2>4th Floor</Address2>
               <City>New York</City>
               <State>NY</State>
               <Zip>10012</Zip>
               <Country>USA</Country>
-              <Email>stephen@strange.com</Email>
+              <Email>wade@wilson.com</Email>
               <Phone>617 123 4567</Phone>
               <IsResidential>false</IsResidential>
             </CustomerInfo>
@@ -40,13 +40,13 @@ http_interactions:
             </CustomFields>
             <Items>
               <Item>
-                <SKU>SKU1</SKU>
+                <SKU>1007-201-G</SKU>
                 <Qty>1</Qty>
                 <IsGiftWrapped>false</IsGiftWrapped>
                 <CustomFields/>
               </Item>
               <Item>
-                <SKU>SKU2</SKU>
+                <SKU>1008-240-C</SKU>
                 <Qty>2</Qty>
                 <IsGiftWrapped>true</IsGiftWrapped>
                 <CustomFields>
@@ -73,22 +73,27 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=zlbwyp0be1yv0rmesuaqnbmy; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=0syd1mmhtx0fc0jh5oi1ywya; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Mon, 21 Aug 2017 15:28:25 GMT
+      - Thu, 07 Sep 2017 13:38:21 GMT
       connection:
       - close
       content-length:
-      - '170'
+      - '127'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPGVycm9ycz4NCiAgICA8ZXJyb3I+QXR0cmlidXRlICJhcGlLZXkiIGVtcHR5IG9yIG1pc3NpbmcgZnJvbSAiT3JkZXJzIiBlbGVtZW50LjwvZXJyb3I+DQogIDwvZXJyb3JzPg0KPC9yZXNwb25zZT4=
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <errors>
+            <error>Invalid API key</error>
+          </errors>
+        </response>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 15:28:05 GMT
+  recorded_at: Thu, 07 Sep 2017 13:38:21 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/order/save/successfully.yml
+++ b/spec/cassettes/order/save/successfully.yml
@@ -7,8 +7,8 @@ http_interactions:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0"?>
-        <Orders apiKey="ABC123">
-          <Order orderID="R123456789">
+        <Orders apiKey="<API_KEY>">
+          <Order orderID="R987654321">
             <Warehouse warehouseid=""/>
             <ShipMethod>USPS Express</ShipMethod>
             <InfoLine>Additional order details</InfoLine>
@@ -21,15 +21,15 @@ http_interactions:
             <OrderDate>08/20/2017</OrderDate>
             <CustomerInfo>
               <Company/>
-              <FirstName>Stephen</FirstName>
-              <LastName>Strange</LastName>
+              <FirstName>Wade</FirstName>
+              <LastName>Wilson</LastName>
               <Address1>75 Spring St</Address1>
               <Address2>4th Floor</Address2>
               <City>New York</City>
               <State>NY</State>
               <Zip>10012</Zip>
               <Country>USA</Country>
-              <Email>stephen@strange.com</Email>
+              <Email>wade@wilson.com</Email>
               <Phone>617 123 4567</Phone>
               <IsResidential>false</IsResidential>
             </CustomerInfo>
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: 
     headers:
       cache-control:
       - private
@@ -73,32 +73,31 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=1s1qfvkymbhs5wgvphv5r2va; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=utgrb0wyu0t1bdgwajzstvct; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Wed, 06 Sep 2017 21:08:22 GMT
+      - Thu, 07 Sep 2017 13:36:58 GMT
       connection:
       - close
       content-length:
-      - '377'
+      - '291'
     body:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="utf-8"?>
         <response>
           <shipments>
-            <shipment id="91955506" orderID="R123456789"/>
+            <shipment id="91955522" orderID="R987654321"/>
           </shipments>
           <warnings>
-            <warning orderID="R123456789">Order placed on hold: Duplicate Order ID</warning>
-            <warning orderID="R123456789">Order placed on hold: Invalid or missing ship method</warning>
+            <warning orderID="R987654321">Order placed on hold: Invalid or missing ship method</warning>
           </warnings>
           <errors/>
         </response>
-    http_version:
-  recorded_at: Wed, 06 Sep 2017 21:07:37 GMT
+    http_version: 
+  recorded_at: Thu, 07 Sep 2017 13:36:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/order/save/successfully.yml
+++ b/spec/cassettes/order/save/successfully.yml
@@ -8,9 +8,9 @@ http_interactions:
       string: |
         <?xml version="1.0"?>
         <Orders apiKey="ABC123">
-          <Order orderID="XML001">
-            <Warehouse warehouseid="WAREHOUSE_ID"/>
-            <ShipMethod>USPS</ShipMethod>
+          <Order orderID="R123456789">
+            <Warehouse warehouseid=""/>
+            <ShipMethod>USPS Express</ShipMethod>
             <InfoLine>Additional order details</InfoLine>
             <RequiresSignature>false</RequiresSignature>
             <IsInsured>false</IsInsured>
@@ -40,13 +40,13 @@ http_interactions:
             </CustomFields>
             <Items>
               <Item>
-                <SKU>SKU1</SKU>
+                <SKU>1007-201-G</SKU>
                 <Qty>1</Qty>
                 <IsGiftWrapped>false</IsGiftWrapped>
                 <CustomFields/>
               </Item>
               <Item>
-                <SKU>SKU2</SKU>
+                <SKU>1008-240-C</SKU>
                 <Qty>2</Qty>
                 <IsGiftWrapped>true</IsGiftWrapped>
                 <CustomFields>
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       cache-control:
       - private
@@ -73,22 +73,32 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=ztolhn5jcl1zuazurpu11cb2; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=1s1qfvkymbhs5wgvphv5r2va; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Mon, 21 Aug 2017 15:15:07 GMT
+      - Wed, 06 Sep 2017 21:08:22 GMT
       connection:
       - close
       content-length:
-      - '606'
+      - '377'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPHNoaXBtZW50cz4NCiAgICA8c2hpcG1lbnQgaWQ9IjkxNzU1MjUyIiBvcmRlcklEPSJYTUwwMDEiIC8+DQogIDwvc2hpcG1lbnRzPg0KICA8d2FybmluZ3M+DQogICAgPHdhcm5pbmcgb3JkZXJJRD0iWE1MMDAxIj5JbnZhbGlkIFNLVTogU0tVICdTS1UxJyBtaXNzaW5nIChRdHkgPSAxKTwvd2FybmluZz4NCiAgICA8d2FybmluZyBvcmRlcklEPSJYTUwwMDEiPkludmFsaWQgU0tVOiBTS1UgJ1NLVTInIG1pc3NpbmcgKFF0eSA9IDIpPC93YXJuaW5nPg0KICAgIDx3YXJuaW5nIG9yZGVySUQ9IlhNTDAwMSI+T3JkZXIgcGxhY2VkIG9uIGhvbGQ6IER1cGxpY2F0ZSBPcmRlciBJRDwvd2FybmluZz4NCiAgICA8d2FybmluZyBvcmRlcklEPSJYTUwwMDEiPk9yZGVyIHBsYWNlZCBvbiBob2xkOiBObyBDb250ZW50czwvd2FybmluZz4NCiAgICA8d2FybmluZyBvcmRlcklEPSJYTUwwMDEiPk9yZGVyIHBsYWNlZCBvbiBob2xkOiBJbnZhbGlkIG9yIG1pc3Npbmcgc2hpcCBtZXRob2Q8L3dhcm5pbmc+DQogIDwvd2FybmluZ3M+DQogIDxlcnJvcnMgLz4NCjwvcmVzcG9uc2U+
-    http_version: 
-  recorded_at: Mon, 21 Aug 2017 15:14:47 GMT
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <shipments>
+            <shipment id="91955506" orderID="R123456789"/>
+          </shipments>
+          <warnings>
+            <warning orderID="R123456789">Order placed on hold: Duplicate Order ID</warning>
+            <warning orderID="R123456789">Order placed on hold: Invalid or missing ship method</warning>
+          </warnings>
+          <errors/>
+        </response>
+    http_version:
+  recorded_at: Wed, 06 Sep 2017 21:07:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/product/all/failure.yml
+++ b/spec/cassettes/product/all/failure.yml
@@ -21,22 +21,27 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=bt2rlapr1i5gqiwh2a0cpfam; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=wjai5y11s1q5jnl3kpqaha01; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 05 Sep 2017 15:36:55 GMT
+      - Thu, 07 Sep 2017 13:18:53 GMT
       connection:
       - close
       content-length:
       - '127'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPGVycm9ycz4NCiAgICA8ZXJyb3I+SW52YWxpZCBBUEkga2V5PC9lcnJvcj4NCiAgPC9lcnJvcnM+DQo8L3Jlc3BvbnNlPg==
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <errors>
+            <error>Invalid API key</error>
+          </errors>
+        </response>
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:36:56 GMT
+  recorded_at: Thu, 07 Sep 2017 13:18:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/product/all/success.yml
+++ b/spec/cassettes/product/all/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://apistaging.newgisticsfulfillment.com/inventory.aspx?key=ABC123
+    uri: https://apistaging.newgisticsfulfillment.com/inventory.aspx?key=<API_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: 
     headers:
       cache-control:
       - private
@@ -21,22 +21,176 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=ilzdl3hxawyf02pbfmry0ngf; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=yljirvcysrojvb5szwvo25sw; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 05 Sep 2017 15:36:55 GMT
+      - Thu, 07 Sep 2017 13:17:19 GMT
       connection:
       - close
       content-length:
-      - '6806'
+      - '6808'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPHByb2R1Y3RzPg0KICAgIDxwcm9kdWN0IGlkPSIxNDg0NTY1IiBza3U9IjEwMDctMjAxLUciPg0KICAgICAgPHJlY2VpdmluZ1F1YW50aXR5PjA8L3JlY2VpdmluZ1F1YW50aXR5Pg0KICAgICAgPGFycml2ZWRQdXRBd2F5UXVhbnRpdHk+MDwvYXJyaXZlZFB1dEF3YXlRdWFudGl0eT4NCiAgICAgIDxwdXRhd2F5UXVhbnRpdHk+MDwvcHV0YXdheVF1YW50aXR5Pg0KICAgICAgPHF1YXJhbnRpbmVRdWFudGl0eT4wPC9xdWFyYW50aW5lUXVhbnRpdHk+DQogICAgICA8ZGFtYWdlZFF1YW50aXR5PjA8L2RhbWFnZWRRdWFudGl0eT4NCiAgICAgIDxleHBpcmVkUXVhbnRpdHk+MDwvZXhwaXJlZFF1YW50aXR5Pg0KICAgICAgPHJlY2FsbGVkUXVhbnRpdHk+MDwvcmVjYWxsZWRRdWFudGl0eT4NCiAgICAgIDxyZXR1cm5zUXVhbnRpdHk+MDwvcmV0dXJuc1F1YW50aXR5Pg0KICAgICAgPGN1cnJlbnRRdWFudGl0eT4wPC9jdXJyZW50UXVhbnRpdHk+DQogICAgICA8a2l0dGluZ1F1YW50aXR5PjA8L2tpdHRpbmdRdWFudGl0eT4NCiAgICAgIDxwZW5kaW5nUXVhbnRpdHk+MDwvcGVuZGluZ1F1YW50aXR5Pg0KICAgICAgPGF2YWlsYWJsZVF1YW50aXR5PjA8L2F2YWlsYWJsZVF1YW50aXR5Pg0KICAgICAgPGJhY2tvcmRlcmVkUXVhbnRpdHk+MDwvYmFja29yZGVyZWRRdWFudGl0eT4NCiAgICA8L3Byb2R1Y3Q+DQogICAgPHByb2R1Y3QgaWQ9IjE0ODQ1NjYiIHNrdT0iMTAwOC0yNDAtQyI+DQogICAgICA8cmVjZWl2aW5nUXVhbnRpdHk+MDwvcmVjZWl2aW5nUXVhbnRpdHk+DQogICAgICA8YXJyaXZlZFB1dEF3YXlRdWFudGl0eT4wPC9hcnJpdmVkUHV0QXdheVF1YW50aXR5Pg0KICAgICAgPHB1dGF3YXlRdWFudGl0eT4wPC9wdXRhd2F5UXVhbnRpdHk+DQogICAgICA8cXVhcmFudGluZVF1YW50aXR5PjA8L3F1YXJhbnRpbmVRdWFudGl0eT4NCiAgICAgIDxkYW1hZ2VkUXVhbnRpdHk+MDwvZGFtYWdlZFF1YW50aXR5Pg0KICAgICAgPGV4cGlyZWRRdWFudGl0eT4wPC9leHBpcmVkUXVhbnRpdHk+DQogICAgICA8cmVjYWxsZWRRdWFudGl0eT4wPC9yZWNhbGxlZFF1YW50aXR5Pg0KICAgICAgPHJldHVybnNRdWFudGl0eT4wPC9yZXR1cm5zUXVhbnRpdHk+DQogICAgICA8Y3VycmVudFF1YW50aXR5PjA8L2N1cnJlbnRRdWFudGl0eT4NCiAgICAgIDxraXR0aW5nUXVhbnRpdHk+MDwva2l0dGluZ1F1YW50aXR5Pg0KICAgICAgPHBlbmRpbmdRdWFudGl0eT4wPC9wZW5kaW5nUXVhbnRpdHk+DQogICAgICA8YXZhaWxhYmxlUXVhbnRpdHk+MDwvYXZhaWxhYmxlUXVhbnRpdHk+DQogICAgICA8YmFja29yZGVyZWRRdWFudGl0eT4wPC9iYWNrb3JkZXJlZFF1YW50aXR5Pg0KICAgIDwvcHJvZHVjdD4NCiAgICA8cHJvZHVjdCBpZD0iMTQ4NDU2NyIgc2t1PSIyMDEwLTAyNS1FIj4NCiAgICAgIDxyZWNlaXZpbmdRdWFudGl0eT4wPC9yZWNlaXZpbmdRdWFudGl0eT4NCiAgICAgIDxhcnJpdmVkUHV0QXdheVF1YW50aXR5PjA8L2Fycml2ZWRQdXRBd2F5UXVhbnRpdHk+DQogICAgICA8cHV0YXdheVF1YW50aXR5PjA8L3B1dGF3YXlRdWFudGl0eT4NCiAgICAgIDxxdWFyYW50aW5lUXVhbnRpdHk+MDwvcXVhcmFudGluZVF1YW50aXR5Pg0KICAgICAgPGRhbWFnZWRRdWFudGl0eT4wPC9kYW1hZ2VkUXVhbnRpdHk+DQogICAgICA8ZXhwaXJlZFF1YW50aXR5PjA8L2V4cGlyZWRRdWFudGl0eT4NCiAgICAgIDxyZWNhbGxlZFF1YW50aXR5PjA8L3JlY2FsbGVkUXVhbnRpdHk+DQogICAgICA8cmV0dXJuc1F1YW50aXR5PjA8L3JldHVybnNRdWFudGl0eT4NCiAgICAgIDxjdXJyZW50UXVhbnRpdHk+MDwvY3VycmVudFF1YW50aXR5Pg0KICAgICAgPGtpdHRpbmdRdWFudGl0eT4wPC9raXR0aW5nUXVhbnRpdHk+DQogICAgICA8cGVuZGluZ1F1YW50aXR5PjA8L3BlbmRpbmdRdWFudGl0eT4NCiAgICAgIDxhdmFpbGFibGVRdWFudGl0eT4wPC9hdmFpbGFibGVRdWFudGl0eT4NCiAgICAgIDxiYWNrb3JkZXJlZFF1YW50aXR5PjA8L2JhY2tvcmRlcmVkUXVhbnRpdHk+DQogICAgPC9wcm9kdWN0Pg0KICAgIDxwcm9kdWN0IGlkPSIxNDg0NTc0IiBza3U9IjMwMzYtMjcwLUMiPg0KICAgICAgPHJlY2VpdmluZ1F1YW50aXR5PjA8L3JlY2VpdmluZ1F1YW50aXR5Pg0KICAgICAgPGFycml2ZWRQdXRBd2F5UXVhbnRpdHk+MDwvYXJyaXZlZFB1dEF3YXlRdWFudGl0eT4NCiAgICAgIDxwdXRhd2F5UXVhbnRpdHk+MDwvcHV0YXdheVF1YW50aXR5Pg0KICAgICAgPHF1YXJhbnRpbmVRdWFudGl0eT4wPC9xdWFyYW50aW5lUXVhbnRpdHk+DQogICAgICA8ZGFtYWdlZFF1YW50aXR5PjA8L2RhbWFnZWRRdWFudGl0eT4NCiAgICAgIDxleHBpcmVkUXVhbnRpdHk+MDwvZXhwaXJlZFF1YW50aXR5Pg0KICAgICAgPHJlY2FsbGVkUXVhbnRpdHk+MDwvcmVjYWxsZWRRdWFudGl0eT4NCiAgICAgIDxyZXR1cm5zUXVhbnRpdHk+MDwvcmV0dXJuc1F1YW50aXR5Pg0KICAgICAgPGN1cnJlbnRRdWFudGl0eT4wPC9jdXJyZW50UXVhbnRpdHk+DQogICAgICA8a2l0dGluZ1F1YW50aXR5PjA8L2tpdHRpbmdRdWFudGl0eT4NCiAgICAgIDxwZW5kaW5nUXVhbnRpdHk+MDwvcGVuZGluZ1F1YW50aXR5Pg0KICAgICAgPGF2YWlsYWJsZVF1YW50aXR5PjA8L2F2YWlsYWJsZVF1YW50aXR5Pg0KICAgICAgPGJhY2tvcmRlcmVkUXVhbnRpdHk+MDwvYmFja29yZGVyZWRRdWFudGl0eT4NCiAgICA8L3Byb2R1Y3Q+DQogICAgPHByb2R1Y3QgaWQ9IjE0ODQ1NzIiIHNrdT0iNDAzNS0wMDgtRyI+DQogICAgICA8cmVjZWl2aW5nUXVhbnRpdHk+MDwvcmVjZWl2aW5nUXVhbnRpdHk+DQogICAgICA8YXJyaXZlZFB1dEF3YXlRdWFudGl0eT4wPC9hcnJpdmVkUHV0QXdheVF1YW50aXR5Pg0KICAgICAgPHB1dGF3YXlRdWFudGl0eT4wPC9wdXRhd2F5UXVhbnRpdHk+DQogICAgICA8cXVhcmFudGluZVF1YW50aXR5PjA8L3F1YXJhbnRpbmVRdWFudGl0eT4NCiAgICAgIDxkYW1hZ2VkUXVhbnRpdHk+MDwvZGFtYWdlZFF1YW50aXR5Pg0KICAgICAgPGV4cGlyZWRRdWFudGl0eT4wPC9leHBpcmVkUXVhbnRpdHk+DQogICAgICA8cmVjYWxsZWRRdWFudGl0eT4wPC9yZWNhbGxlZFF1YW50aXR5Pg0KICAgICAgPHJldHVybnNRdWFudGl0eT4wPC9yZXR1cm5zUXVhbnRpdHk+DQogICAgICA8Y3VycmVudFF1YW50aXR5PjA8L2N1cnJlbnRRdWFudGl0eT4NCiAgICAgIDxraXR0aW5nUXVhbnRpdHk+MDwva2l0dGluZ1F1YW50aXR5Pg0KICAgICAgPHBlbmRpbmdRdWFudGl0eT4wPC9wZW5kaW5nUXVhbnRpdHk+DQogICAgICA8YXZhaWxhYmxlUXVhbnRpdHk+MDwvYXZhaWxhYmxlUXVhbnRpdHk+DQogICAgICA8YmFja29yZGVyZWRRdWFudGl0eT4wPC9iYWNrb3JkZXJlZFF1YW50aXR5Pg0KICAgIDwvcHJvZHVjdD4NCiAgICA8cHJvZHVjdCBpZD0iMTQ4NDU2OCIgc2t1PSI1MDQ1LTkwMS1CIj4NCiAgICAgIDxyZWNlaXZpbmdRdWFudGl0eT4wPC9yZWNlaXZpbmdRdWFudGl0eT4NCiAgICAgIDxhcnJpdmVkUHV0QXdheVF1YW50aXR5PjA8L2Fycml2ZWRQdXRBd2F5UXVhbnRpdHk+DQogICAgICA8cHV0YXdheVF1YW50aXR5PjA8L3B1dGF3YXlRdWFudGl0eT4NCiAgICAgIDxxdWFyYW50aW5lUXVhbnRpdHk+MDwvcXVhcmFudGluZVF1YW50aXR5Pg0KICAgICAgPGRhbWFnZWRRdWFudGl0eT4wPC9kYW1hZ2VkUXVhbnRpdHk+DQogICAgICA8ZXhwaXJlZFF1YW50aXR5PjA8L2V4cGlyZWRRdWFudGl0eT4NCiAgICAgIDxyZWNhbGxlZFF1YW50aXR5PjA8L3JlY2FsbGVkUXVhbnRpdHk+DQogICAgICA8cmV0dXJuc1F1YW50aXR5PjA8L3JldHVybnNRdWFudGl0eT4NCiAgICAgIDxjdXJyZW50UXVhbnRpdHk+MDwvY3VycmVudFF1YW50aXR5Pg0KICAgICAgPGtpdHRpbmdRdWFudGl0eT4wPC9raXR0aW5nUXVhbnRpdHk+DQogICAgICA8cGVuZGluZ1F1YW50aXR5PjA8L3BlbmRpbmdRdWFudGl0eT4NCiAgICAgIDxhdmFpbGFibGVRdWFudGl0eT4wPC9hdmFpbGFibGVRdWFudGl0eT4NCiAgICAgIDxiYWNrb3JkZXJlZFF1YW50aXR5PjA8L2JhY2tvcmRlcmVkUXVhbnRpdHk+DQogICAgPC9wcm9kdWN0Pg0KICAgIDxwcm9kdWN0IGlkPSIxNDg0NTcxIiBza3U9IjUxNzktNTA2LUciPg0KICAgICAgPHJlY2VpdmluZ1F1YW50aXR5PjA8L3JlY2VpdmluZ1F1YW50aXR5Pg0KICAgICAgPGFycml2ZWRQdXRBd2F5UXVhbnRpdHk+MDwvYXJyaXZlZFB1dEF3YXlRdWFudGl0eT4NCiAgICAgIDxwdXRhd2F5UXVhbnRpdHk+MDwvcHV0YXdheVF1YW50aXR5Pg0KICAgICAgPHF1YXJhbnRpbmVRdWFudGl0eT4wPC9xdWFyYW50aW5lUXVhbnRpdHk+DQogICAgICA8ZGFtYWdlZFF1YW50aXR5PjA8L2RhbWFnZWRRdWFudGl0eT4NCiAgICAgIDxleHBpcmVkUXVhbnRpdHk+MDwvZXhwaXJlZFF1YW50aXR5Pg0KICAgICAgPHJlY2FsbGVkUXVhbnRpdHk+MDwvcmVjYWxsZWRRdWFudGl0eT4NCiAgICAgIDxyZXR1cm5zUXVhbnRpdHk+MDwvcmV0dXJuc1F1YW50aXR5Pg0KICAgICAgPGN1cnJlbnRRdWFudGl0eT4wPC9jdXJyZW50UXVhbnRpdHk+DQogICAgICA8a2l0dGluZ1F1YW50aXR5PjA8L2tpdHRpbmdRdWFudGl0eT4NCiAgICAgIDxwZW5kaW5nUXVhbnRpdHk+MDwvcGVuZGluZ1F1YW50aXR5Pg0KICAgICAgPGF2YWlsYWJsZVF1YW50aXR5PjA8L2F2YWlsYWJsZVF1YW50aXR5Pg0KICAgICAgPGJhY2tvcmRlcmVkUXVhbnRpdHk+MDwvYmFja29yZGVyZWRRdWFudGl0eT4NCiAgICA8L3Byb2R1Y3Q+DQogICAgPHByb2R1Y3QgaWQ9IjE0ODQ1NjkiIHNrdT0iNzAwMEEtMDAyLUciPg0KICAgICAgPHJlY2VpdmluZ1F1YW50aXR5PjA8L3JlY2VpdmluZ1F1YW50aXR5Pg0KICAgICAgPGFycml2ZWRQdXRBd2F5UXVhbnRpdHk+MDwvYXJyaXZlZFB1dEF3YXlRdWFudGl0eT4NCiAgICAgIDxwdXRhd2F5UXVhbnRpdHk+MDwvcHV0YXdheVF1YW50aXR5Pg0KICAgICAgPHF1YXJhbnRpbmVRdWFudGl0eT4wPC9xdWFyYW50aW5lUXVhbnRpdHk+DQogICAgICA8ZGFtYWdlZFF1YW50aXR5PjA8L2RhbWFnZWRRdWFudGl0eT4NCiAgICAgIDxleHBpcmVkUXVhbnRpdHk+MDwvZXhwaXJlZFF1YW50aXR5Pg0KICAgICAgPHJlY2FsbGVkUXVhbnRpdHk+MDwvcmVjYWxsZWRRdWFudGl0eT4NCiAgICAgIDxyZXR1cm5zUXVhbnRpdHk+MDwvcmV0dXJuc1F1YW50aXR5Pg0KICAgICAgPGN1cnJlbnRRdWFudGl0eT4wPC9jdXJyZW50UXVhbnRpdHk+DQogICAgICA8a2l0dGluZ1F1YW50aXR5PjA8L2tpdHRpbmdRdWFudGl0eT4NCiAgICAgIDxwZW5kaW5nUXVhbnRpdHk+MDwvcGVuZGluZ1F1YW50aXR5Pg0KICAgICAgPGF2YWlsYWJsZVF1YW50aXR5PjA8L2F2YWlsYWJsZVF1YW50aXR5Pg0KICAgICAgPGJhY2tvcmRlcmVkUXVhbnRpdHk+MDwvYmFja29yZGVyZWRRdWFudGl0eT4NCiAgICA8L3Byb2R1Y3Q+DQogICAgPHByb2R1Y3QgaWQ9IjE0ODQ1NzMiIHNrdT0iODAyNC0yNTgtQyI+DQogICAgICA8cmVjZWl2aW5nUXVhbnRpdHk+MDwvcmVjZWl2aW5nUXVhbnRpdHk+DQogICAgICA8YXJyaXZlZFB1dEF3YXlRdWFudGl0eT4wPC9hcnJpdmVkUHV0QXdheVF1YW50aXR5Pg0KICAgICAgPHB1dGF3YXlRdWFudGl0eT4wPC9wdXRhd2F5UXVhbnRpdHk+DQogICAgICA8cXVhcmFudGluZVF1YW50aXR5PjA8L3F1YXJhbnRpbmVRdWFudGl0eT4NCiAgICAgIDxkYW1hZ2VkUXVhbnRpdHk+MDwvZGFtYWdlZFF1YW50aXR5Pg0KICAgICAgPGV4cGlyZWRRdWFudGl0eT4wPC9leHBpcmVkUXVhbnRpdHk+DQogICAgICA8cmVjYWxsZWRRdWFudGl0eT4wPC9yZWNhbGxlZFF1YW50aXR5Pg0KICAgICAgPHJldHVybnNRdWFudGl0eT4wPC9yZXR1cm5zUXVhbnRpdHk+DQogICAgICA8Y3VycmVudFF1YW50aXR5PjA8L2N1cnJlbnRRdWFudGl0eT4NCiAgICAgIDxraXR0aW5nUXVhbnRpdHk+MDwva2l0dGluZ1F1YW50aXR5Pg0KICAgICAgPHBlbmRpbmdRdWFudGl0eT4wPC9wZW5kaW5nUXVhbnRpdHk+DQogICAgICA8YXZhaWxhYmxlUXVhbnRpdHk+MDwvYXZhaWxhYmxlUXVhbnRpdHk+DQogICAgICA8YmFja29yZGVyZWRRdWFudGl0eT4wPC9iYWNrb3JkZXJlZFF1YW50aXR5Pg0KICAgIDwvcHJvZHVjdD4NCiAgICA8cHJvZHVjdCBpZD0iMTQ4NDU3MCIgc2t1PSI4MDI4LTAwNy1DIj4NCiAgICAgIDxyZWNlaXZpbmdRdWFudGl0eT4wPC9yZWNlaXZpbmdRdWFudGl0eT4NCiAgICAgIDxhcnJpdmVkUHV0QXdheVF1YW50aXR5PjA8L2Fycml2ZWRQdXRBd2F5UXVhbnRpdHk+DQogICAgICA8cHV0YXdheVF1YW50aXR5PjA8L3B1dGF3YXlRdWFudGl0eT4NCiAgICAgIDxxdWFyYW50aW5lUXVhbnRpdHk+MDwvcXVhcmFudGluZVF1YW50aXR5Pg0KICAgICAgPGRhbWFnZWRRdWFudGl0eT4wPC9kYW1hZ2VkUXVhbnRpdHk+DQogICAgICA8ZXhwaXJlZFF1YW50aXR5PjA8L2V4cGlyZWRRdWFudGl0eT4NCiAgICAgIDxyZWNhbGxlZFF1YW50aXR5PjA8L3JlY2FsbGVkUXVhbnRpdHk+DQogICAgICA8cmV0dXJuc1F1YW50aXR5PjA8L3JldHVybnNRdWFudGl0eT4NCiAgICAgIDxjdXJyZW50UXVhbnRpdHk+MDwvY3VycmVudFF1YW50aXR5Pg0KICAgICAgPGtpdHRpbmdRdWFudGl0eT4wPC9raXR0aW5nUXVhbnRpdHk+DQogICAgICA8cGVuZGluZ1F1YW50aXR5PjA8L3BlbmRpbmdRdWFudGl0eT4NCiAgICAgIDxhdmFpbGFibGVRdWFudGl0eT4wPC9hdmFpbGFibGVRdWFudGl0eT4NCiAgICAgIDxiYWNrb3JkZXJlZFF1YW50aXR5PjA8L2JhY2tvcmRlcmVkUXVhbnRpdHk+DQogICAgPC9wcm9kdWN0Pg0KICA8L3Byb2R1Y3RzPg0KPC9yZXNwb25zZT4=
-    http_version:
-  recorded_at: Tue, 05 Sep 2017 15:36:56 GMT
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <products>
+            <product id="1484565" sku="1007-201-G">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>1</pendingQuantity>
+              <availableQuantity>-1</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484566" sku="1008-240-C">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>2</pendingQuantity>
+              <availableQuantity>-2</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484567" sku="2010-025-E">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484574" sku="3036-270-C">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484572" sku="4035-008-G">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484568" sku="5045-901-B">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484571" sku="5179-506-G">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484569" sku="7000A-002-G">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484573" sku="8024-258-C">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+            <product id="1484570" sku="8028-007-C">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+          </products>
+        </response>
+    http_version: 
+  recorded_at: Thu, 07 Sep 2017 13:17:19 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/product/where/failure.yml
+++ b/spec/cassettes/product/where/failure.yml
@@ -21,22 +21,27 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=zq0jvm4p3g5stslhhfagabts; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=1igu1famx42bttt1vtgh5dxn; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 05 Sep 2017 15:36:55 GMT
+      - Thu, 07 Sep 2017 13:16:57 GMT
       connection:
       - close
       content-length:
       - '127'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPGVycm9ycz4NCiAgICA8ZXJyb3I+SW52YWxpZCBBUEkga2V5PC9lcnJvcj4NCiAgPC9lcnJvcnM+DQo8L3Jlc3BvbnNlPg==
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <errors>
+            <error>Invalid API key</error>
+          </errors>
+        </response>
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:36:56 GMT
+  recorded_at: Thu, 07 Sep 2017 13:16:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/product/where/success.yml
+++ b/spec/cassettes/product/where/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://apistaging.newgisticsfulfillment.com/inventory.aspx?key=ABC123&sku=2010-025-E
+    uri: https://apistaging.newgisticsfulfillment.com/inventory.aspx?key=<API_KEY>&sku=2010-025-E
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: 
     headers:
       cache-control:
       - private
@@ -21,22 +21,41 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=y1w23dzox01xunkwdvlp43hg; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=tlezpu40lkzwvy3z3zigjb1g; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 05 Sep 2017 15:36:55 GMT
+      - Thu, 07 Sep 2017 13:16:17 GMT
       connection:
       - close
       content-length:
       - '766'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPHByb2R1Y3RzPg0KICAgIDxwcm9kdWN0IGlkPSIxNDg0NTY3IiBza3U9IjIwMTAtMDI1LUUiPg0KICAgICAgPHJlY2VpdmluZ1F1YW50aXR5PjA8L3JlY2VpdmluZ1F1YW50aXR5Pg0KICAgICAgPGFycml2ZWRQdXRBd2F5UXVhbnRpdHk+MDwvYXJyaXZlZFB1dEF3YXlRdWFudGl0eT4NCiAgICAgIDxwdXRhd2F5UXVhbnRpdHk+MDwvcHV0YXdheVF1YW50aXR5Pg0KICAgICAgPHF1YXJhbnRpbmVRdWFudGl0eT4wPC9xdWFyYW50aW5lUXVhbnRpdHk+DQogICAgICA8ZGFtYWdlZFF1YW50aXR5PjA8L2RhbWFnZWRRdWFudGl0eT4NCiAgICAgIDxleHBpcmVkUXVhbnRpdHk+MDwvZXhwaXJlZFF1YW50aXR5Pg0KICAgICAgPHJlY2FsbGVkUXVhbnRpdHk+MDwvcmVjYWxsZWRRdWFudGl0eT4NCiAgICAgIDxyZXR1cm5zUXVhbnRpdHk+MDwvcmV0dXJuc1F1YW50aXR5Pg0KICAgICAgPGN1cnJlbnRRdWFudGl0eT4wPC9jdXJyZW50UXVhbnRpdHk+DQogICAgICA8a2l0dGluZ1F1YW50aXR5PjA8L2tpdHRpbmdRdWFudGl0eT4NCiAgICAgIDxwZW5kaW5nUXVhbnRpdHk+MDwvcGVuZGluZ1F1YW50aXR5Pg0KICAgICAgPGF2YWlsYWJsZVF1YW50aXR5PjA8L2F2YWlsYWJsZVF1YW50aXR5Pg0KICAgICAgPGJhY2tvcmRlcmVkUXVhbnRpdHk+MDwvYmFja29yZGVyZWRRdWFudGl0eT4NCiAgICA8L3Byb2R1Y3Q+DQogIDwvcHJvZHVjdHM+DQo8L3Jlc3BvbnNlPg==
-    http_version:
-  recorded_at: Tue, 05 Sep 2017 15:36:56 GMT
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <products>
+            <product id="1484567" sku="2010-025-E">
+              <receivingQuantity>0</receivingQuantity>
+              <arrivedPutAwayQuantity>0</arrivedPutAwayQuantity>
+              <putawayQuantity>0</putawayQuantity>
+              <quarantineQuantity>0</quarantineQuantity>
+              <damagedQuantity>0</damagedQuantity>
+              <expiredQuantity>0</expiredQuantity>
+              <recalledQuantity>0</recalledQuantity>
+              <returnsQuantity>0</returnsQuantity>
+              <currentQuantity>0</currentQuantity>
+              <kittingQuantity>0</kittingQuantity>
+              <pendingQuantity>0</pendingQuantity>
+              <availableQuantity>0</availableQuantity>
+              <backorderedQuantity>0</backorderedQuantity>
+            </product>
+          </products>
+        </response>
+    http_version: 
+  recorded_at: Thu, 07 Sep 2017 13:16:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/return/where/failure.yml
+++ b/spec/cassettes/return/where/failure.yml
@@ -12,7 +12,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: 
     headers:
       cache-control:
       - private
@@ -21,22 +21,27 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=h0bcvlkihxftk3fhpi5cndpe; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=jak3adi4snwaabvzoakadwc0; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Thu, 24 Aug 2017 20:54:59 GMT
+      - Thu, 07 Sep 2017 13:14:28 GMT
       connection:
       - close
       content-length:
       - '127'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPGVycm9ycz4NCiAgICA8ZXJyb3I+SW52YWxpZCBBUEkga2V5PC9lcnJvcj4NCiAgPC9lcnJvcnM+DQo8L3Jlc3BvbnNlPg==
-    http_version:
-  recorded_at: Thu, 24 Aug 2017 20:54:33 GMT
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <errors>
+            <error>Invalid API key</error>
+          </errors>
+        </response>
+    http_version: 
+  recorded_at: Thu, 07 Sep 2017 13:14:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/return/where/success.yml
+++ b/spec/cassettes/return/where/success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://apistaging.newgisticsfulfillment.com/returns.aspx?endTimestamp=2017-09-30&key=ABC123&startTimestamp=2017-08-01
+    uri: https://apistaging.newgisticsfulfillment.com/returns.aspx?endTimestamp=2017-09-30&key=<API_KEY>&startTimestamp=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -21,21 +21,22 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=ygfckizx45ayirnydrj5qwxz; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=kkse2jxmo1mojjewcfhgm4et; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 05 Sep 2017 15:51:41 GMT
+      - Thu, 07 Sep 2017 13:12:15 GMT
       connection:
       - close
       content-length:
       - '81'
     body:
-      encoding: ASCII-8BIT
-      string:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
         <response>
           <Returns>
             <Return warehouseID="60" shipmentID="91955463"
@@ -74,5 +75,5 @@ http_interactions:
           </Returns>
         </response>
     http_version:
-  recorded_at: Tue, 05 Sep 2017 15:51:41 GMT
+  recorded_at: Thu, 07 Sep 2017 13:12:15 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/shipment/where/failure.yml
+++ b/spec/cassettes/shipment/where/failure.yml
@@ -21,22 +21,27 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=b4spuu5lfdnatwbrtnfdo0gn; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=o45pk35t5encchzpjnnv4zdt; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Wed, 23 Aug 2017 17:09:11 GMT
+      - Thu, 07 Sep 2017 13:21:23 GMT
       connection:
       - close
       content-length:
       - '127'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxyZXNwb25zZT4NCiAgPGVycm9ycz4NCiAgICA8ZXJyb3I+SW52YWxpZCBBUEkga2V5PC9lcnJvcj4NCiAgPC9lcnJvcnM+DQo8L3Jlc3BvbnNlPg==
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <response>
+          <errors>
+            <error>Invalid API key</error>
+          </errors>
+        </response>
     http_version: 
-  recorded_at: Wed, 23 Aug 2017 17:09:12 GMT
+  recorded_at: Thu, 07 Sep 2017 13:21:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/shipment/where/successfully.yml
+++ b/spec/cassettes/shipment/where/successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://apistaging.newgisticsfulfillment.com/shipments.aspx?endReceivedTimestamp=2017-08-22&key=ABC123&startReceivedTimestamp=2017-08-01
+    uri: https://apistaging.newgisticsfulfillment.com/shipments.aspx?endReceivedTimestamp=2017-09-07&key=ABC123&startReceivedTimestamp=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -21,22 +21,151 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=jd0qoehkucectg2k2mfqi2g4; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=qqojkowhl42dqzgaigjwoqgv; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Tue, 22 Aug 2017 20:16:56 GMT
+      - Wed, 06 Sep 2017 21:09:43 GMT
       connection:
       - close
       content-length:
-      - '8773'
+      - '3894'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjxTaGlwbWVudHM+DQogIDxTaGlwbWVudCBpZD0iOTE3NTUyNDkiPg0KICAgIDxDbGllbnROYW1lPlJvY2tldHMgb2YgQXdlc29tZTwvQ2xpZW50TmFtZT4NCiAgICA8T3JkZXJJRD5YTUwwMDE8L09yZGVySUQ+DQogICAgPFB1cmNoYXNlT3JkZXIgLz4NCiAgICA8TmFtZT5TVEVQSEVOIFNUUkFOR0U8L05hbWU+DQogICAgPEZpcnN0TmFtZT5TVEVQSEVOPC9GaXJzdE5hbWU+DQogICAgPExhc3ROYW1lPlNUUkFOR0U8L0xhc3ROYW1lPg0KICAgIDxDb21wYW55IC8+DQogICAgPEFkZHJlc3MxPjc1IFNQUklORyBTVCBGTCA0PC9BZGRyZXNzMT4NCiAgICA8QWRkcmVzczIgLz4NCiAgICA8Q2l0eT5ORVcgWU9SSzwvQ2l0eT4NCiAgICA8U3RhdGU+Tlk8L1N0YXRlPg0KICAgIDxQb3N0YWxDb2RlPjEwMDEyLTQwOTY8L1Bvc3RhbENvZGU+DQogICAgPENvdW50cnk+VU5JVEVEIFNUQVRFUzwvQ291bnRyeT4NCiAgICA8RW1haWw+c3RlcGhlbkBzdHJhbmdlLmNvbTwvRW1haWw+DQogICAgPFBob25lPjYxNyAxMjMgNDU2NzwvUGhvbmU+DQogICAgPE9yZGVyVGltZXN0YW1wPjIwMTctMDgtMjBUMDA6MDA6MDA8L09yZGVyVGltZXN0YW1wPg0KICAgIDxSZWNlaXZlZFRpbWVzdGFtcD4yMDE3LTA4LTIxVDA3OjIyOjAzLjQxMzwvUmVjZWl2ZWRUaW1lc3RhbXA+DQogICAgPFNoaXBtZW50U3RhdHVzPk9OSE9MRDwvU2hpcG1lbnRTdGF0dXM+DQogICAgPE9yZGVyVHlwZT5Db25zdW1lcjwvT3JkZXJUeXBlPg0KICAgIDxTaGlwcGVkRGF0ZSAvPg0KICAgIDxFeHBlY3RlZERlbGl2ZXJ5RGF0ZSAvPg0KICAgIDxEZWxpdmVyZWRUaW1lc3RhbXAgLz4NCiAgICA8RGVsaXZlcnlFeGNlcHRpb24gLz4NCiAgICA8V2FyZWhvdXNlIGlkPSIxNTciPg0KICAgICAgPE5hbWU+SGVicm9uLCBLWTwvTmFtZT4NCiAgICAgIDxBZGRyZXNzPjEyMDAgV09STERXSURFIEJMVkQ8L0FkZHJlc3M+DQogICAgICA8Q2l0eT5IRUJST048L0NpdHk+DQogICAgICA8U3RhdGU+S1k8L1N0YXRlPg0KICAgICAgPFBvc3RhbENvZGU+NDEwNDg8L1Bvc3RhbENvZGU+DQogICAgICA8Q291bnRyeT5VUzwvQ291bnRyeT4NCiAgICA8L1dhcmVob3VzZT4NCiAgICA8U2hpcE1ldGhvZD5Ib2xkLCBEbyAgTm90IFNoaXA8L1NoaXBNZXRob2Q+DQogICAgPFNoaXBNZXRob2RDb2RlPkhPTEQ8L1NoaXBNZXRob2RDb2RlPg0KICAgIDxUcmFja2luZyAvPg0KICAgIDxUcmFja2luZ1VybCAvPg0KICAgIDxXZWlnaHQgLz4NCiAgICA8UG9zdGFnZSAvPg0KICAgIDxHaWZ0V3JhcD5mYWxzZTwvR2lmdFdyYXA+DQogICAgPEN1c3RvbUZpZWxkcz4NCiAgICAgIDxBZGRpdGlvbmFsVGF4PjE1LjA8L0FkZGl0aW9uYWxUYXg+DQogICAgICA8U3VidG90YWw+MTAuMDwvU3VidG90YWw+DQogICAgICA8VG90YWw+MjUuMDwvVG90YWw+DQogICAgPC9DdXN0b21GaWVsZHM+DQogICAgPEJhY2tvcmRlcmVkSXRlbXMgLz4NCiAgICA8SXRlbXMgLz4NCiAgICA8UGFja2FnZXMgLz4NCiAgPC9TaGlwbWVudD4NCiAgPFNoaXBtZW50IGlkPSI5MTc1NTI1MSI+DQogICAgPENsaWVudE5hbWU+Um9ja2V0cyBvZiBBd2Vzb21lPC9DbGllbnROYW1lPg0KICAgIDxPcmRlcklEPlhNTDAwMTwvT3JkZXJJRD4NCiAgICA8UHVyY2hhc2VPcmRlciAvPg0KICAgIDxOYW1lPlNURVBIRU4gU1RSQU5HRTwvTmFtZT4NCiAgICA8Rmlyc3ROYW1lPlNURVBIRU48L0ZpcnN0TmFtZT4NCiAgICA8TGFzdE5hbWU+U1RSQU5HRTwvTGFzdE5hbWU+DQogICAgPENvbXBhbnkgLz4NCiAgICA8QWRkcmVzczE+NzUgU1BSSU5HIFNUIEZMIDQ8L0FkZHJlc3MxPg0KICAgIDxBZGRyZXNzMiAvPg0KICAgIDxDaXR5Pk5FVyBZT1JLPC9DaXR5Pg0KICAgIDxTdGF0ZT5OWTwvU3RhdGU+DQogICAgPFBvc3RhbENvZGU+MTAwMTItNDA5NjwvUG9zdGFsQ29kZT4NCiAgICA8Q291bnRyeT5VTklURUQgU1RBVEVTPC9Db3VudHJ5Pg0KICAgIDxFbWFpbD5zdGVwaGVuQHN0cmFuZ2UuY29tPC9FbWFpbD4NCiAgICA8UGhvbmU+NjE3IDEyMyA0NTY3PC9QaG9uZT4NCiAgICA8T3JkZXJUaW1lc3RhbXA+MjAxNy0wOC0yMFQwMDowMDowMDwvT3JkZXJUaW1lc3RhbXA+DQogICAgPFJlY2VpdmVkVGltZXN0YW1wPjIwMTctMDgtMjFUMDk6MDg6NTMuMzMwPC9SZWNlaXZlZFRpbWVzdGFtcD4NCiAgICA8U2hpcG1lbnRTdGF0dXM+T05IT0xEPC9TaGlwbWVudFN0YXR1cz4NCiAgICA8T3JkZXJUeXBlPkNvbnN1bWVyPC9PcmRlclR5cGU+DQogICAgPFNoaXBwZWREYXRlIC8+DQogICAgPEV4cGVjdGVkRGVsaXZlcnlEYXRlIC8+DQogICAgPERlbGl2ZXJlZFRpbWVzdGFtcCAvPg0KICAgIDxEZWxpdmVyeUV4Y2VwdGlvbiAvPg0KICAgIDxXYXJlaG91c2UgaWQ9IjE1NyI+DQogICAgICA8TmFtZT5IZWJyb24sIEtZPC9OYW1lPg0KICAgICAgPEFkZHJlc3M+MTIwMCBXT1JMRFdJREUgQkxWRDwvQWRkcmVzcz4NCiAgICAgIDxDaXR5PkhFQlJPTjwvQ2l0eT4NCiAgICAgIDxTdGF0ZT5LWTwvU3RhdGU+DQogICAgICA8UG9zdGFsQ29kZT40MTA0ODwvUG9zdGFsQ29kZT4NCiAgICAgIDxDb3VudHJ5PlVTPC9Db3VudHJ5Pg0KICAgIDwvV2FyZWhvdXNlPg0KICAgIDxTaGlwTWV0aG9kPkhvbGQsIERvICBOb3QgU2hpcDwvU2hpcE1ldGhvZD4NCiAgICA8U2hpcE1ldGhvZENvZGU+SE9MRDwvU2hpcE1ldGhvZENvZGU+DQogICAgPFRyYWNraW5nIC8+DQogICAgPFRyYWNraW5nVXJsIC8+DQogICAgPFdlaWdodCAvPg0KICAgIDxQb3N0YWdlIC8+DQogICAgPEdpZnRXcmFwPmZhbHNlPC9HaWZ0V3JhcD4NCiAgICA8Q3VzdG9tRmllbGRzPg0KICAgICAgPEFkZGl0aW9uYWxUYXg+MTUuMDwvQWRkaXRpb25hbFRheD4NCiAgICAgIDxTdWJ0b3RhbD4xMC4wPC9TdWJ0b3RhbD4NCiAgICAgIDxUb3RhbD4yNS4wPC9Ub3RhbD4NCiAgICA8L0N1c3RvbUZpZWxkcz4NCiAgICA8QmFja29yZGVyZWRJdGVtcyAvPg0KICAgIDxJdGVtcyAvPg0KICAgIDxQYWNrYWdlcyAvPg0KICA8L1NoaXBtZW50Pg0KICA8U2hpcG1lbnQgaWQ9IjkxNzU1MjUyIj4NCiAgICA8Q2xpZW50TmFtZT5Sb2NrZXRzIG9mIEF3ZXNvbWU8L0NsaWVudE5hbWU+DQogICAgPE9yZGVySUQ+WE1MMDAxPC9PcmRlcklEPg0KICAgIDxQdXJjaGFzZU9yZGVyIC8+DQogICAgPE5hbWU+U1RFUEhFTiBTVFJBTkdFPC9OYW1lPg0KICAgIDxGaXJzdE5hbWU+U1RFUEhFTjwvRmlyc3ROYW1lPg0KICAgIDxMYXN0TmFtZT5TVFJBTkdFPC9MYXN0TmFtZT4NCiAgICA8Q29tcGFueSAvPg0KICAgIDxBZGRyZXNzMT43NSBTUFJJTkcgU1QgRkwgNDwvQWRkcmVzczE+DQogICAgPEFkZHJlc3MyIC8+DQogICAgPENpdHk+TkVXIFlPUks8L0NpdHk+DQogICAgPFN0YXRlPk5ZPC9TdGF0ZT4NCiAgICA8UG9zdGFsQ29kZT4xMDAxMi00MDk2PC9Qb3N0YWxDb2RlPg0KICAgIDxDb3VudHJ5PlVOSVRFRCBTVEFURVM8L0NvdW50cnk+DQogICAgPEVtYWlsPnN0ZXBoZW5Ac3RyYW5nZS5jb208L0VtYWlsPg0KICAgIDxQaG9uZT42MTcgMTIzIDQ1Njc8L1Bob25lPg0KICAgIDxPcmRlclRpbWVzdGFtcD4yMDE3LTA4LTIwVDAwOjAwOjAwPC9PcmRlclRpbWVzdGFtcD4NCiAgICA8UmVjZWl2ZWRUaW1lc3RhbXA+MjAxNy0wOC0yMVQwOToxNTowNi4zOTM8L1JlY2VpdmVkVGltZXN0YW1wPg0KICAgIDxTaGlwbWVudFN0YXR1cz5PTkhPTEQ8L1NoaXBtZW50U3RhdHVzPg0KICAgIDxPcmRlclR5cGU+Q29uc3VtZXI8L09yZGVyVHlwZT4NCiAgICA8U2hpcHBlZERhdGUgLz4NCiAgICA8RXhwZWN0ZWREZWxpdmVyeURhdGUgLz4NCiAgICA8RGVsaXZlcmVkVGltZXN0YW1wIC8+DQogICAgPERlbGl2ZXJ5RXhjZXB0aW9uIC8+DQogICAgPFdhcmVob3VzZSBpZD0iMTU3Ij4NCiAgICAgIDxOYW1lPkhlYnJvbiwgS1k8L05hbWU+DQogICAgICA8QWRkcmVzcz4xMjAwIFdPUkxEV0lERSBCTFZEPC9BZGRyZXNzPg0KICAgICAgPENpdHk+SEVCUk9OPC9DaXR5Pg0KICAgICAgPFN0YXRlPktZPC9TdGF0ZT4NCiAgICAgIDxQb3N0YWxDb2RlPjQxMDQ4PC9Qb3N0YWxDb2RlPg0KICAgICAgPENvdW50cnk+VVM8L0NvdW50cnk+DQogICAgPC9XYXJlaG91c2U+DQogICAgPFNoaXBNZXRob2Q+SG9sZCwgRG8gIE5vdCBTaGlwPC9TaGlwTWV0aG9kPg0KICAgIDxTaGlwTWV0aG9kQ29kZT5IT0xEPC9TaGlwTWV0aG9kQ29kZT4NCiAgICA8VHJhY2tpbmcgLz4NCiAgICA8VHJhY2tpbmdVcmwgLz4NCiAgICA8V2VpZ2h0IC8+DQogICAgPFBvc3RhZ2UgLz4NCiAgICA8R2lmdFdyYXA+ZmFsc2U8L0dpZnRXcmFwPg0KICAgIDxDdXN0b21GaWVsZHM+DQogICAgICA8QWRkaXRpb25hbFRheD4xNS4wPC9BZGRpdGlvbmFsVGF4Pg0KICAgICAgPFN1YnRvdGFsPjEwLjA8L1N1YnRvdGFsPg0KICAgICAgPFRvdGFsPjI1LjA8L1RvdGFsPg0KICAgIDwvQ3VzdG9tRmllbGRzPg0KICAgIDxCYWNrb3JkZXJlZEl0ZW1zIC8+DQogICAgPEl0ZW1zIC8+DQogICAgPFBhY2thZ2VzIC8+DQogIDwvU2hpcG1lbnQ+DQogIDxTaGlwbWVudCBpZD0iOTE3NTUyNTMiPg0KICAgIDxDbGllbnROYW1lPlJvY2tldHMgb2YgQXdlc29tZTwvQ2xpZW50TmFtZT4NCiAgICA8T3JkZXJJRCAvPg0KICAgIDxQdXJjaGFzZU9yZGVyIC8+DQogICAgPE5hbWU+U1RFUEhFTiBTVFJBTkdFPC9OYW1lPg0KICAgIDxGaXJzdE5hbWU+U1RFUEhFTjwvRmlyc3ROYW1lPg0KICAgIDxMYXN0TmFtZT5TVFJBTkdFPC9MYXN0TmFtZT4NCiAgICA8Q29tcGFueSAvPg0KICAgIDxBZGRyZXNzMT43NSBTUFJJTkcgU1QgRkwgNDwvQWRkcmVzczE+DQogICAgPEFkZHJlc3MyIC8+DQogICAgPENpdHk+TkVXIFlPUks8L0NpdHk+DQogICAgPFN0YXRlPk5ZPC9TdGF0ZT4NCiAgICA8UG9zdGFsQ29kZT4xMDAxMi00MDk2PC9Qb3N0YWxDb2RlPg0KICAgIDxDb3VudHJ5PlVOSVRFRCBTVEFURVM8L0NvdW50cnk+DQogICAgPEVtYWlsPnN0ZXBoZW5Ac3RyYW5nZS5jb208L0VtYWlsPg0KICAgIDxQaG9uZT42MTcgMTIzIDQ1Njc8L1Bob25lPg0KICAgIDxPcmRlclRpbWVzdGFtcD4yMDE3LTA4LTIwVDAwOjAwOjAwPC9PcmRlclRpbWVzdGFtcD4NCiAgICA8UmVjZWl2ZWRUaW1lc3RhbXA+MjAxNy0wOC0yMVQwOToxNzowNC45MTA8L1JlY2VpdmVkVGltZXN0YW1wPg0KICAgIDxTaGlwbWVudFN0YXR1cz5PTkhPTEQ8L1NoaXBtZW50U3RhdHVzPg0KICAgIDxPcmRlclR5cGU+Q29uc3VtZXI8L09yZGVyVHlwZT4NCiAgICA8U2hpcHBlZERhdGUgLz4NCiAgICA8RXhwZWN0ZWREZWxpdmVyeURhdGUgLz4NCiAgICA8RGVsaXZlcmVkVGltZXN0YW1wIC8+DQogICAgPERlbGl2ZXJ5RXhjZXB0aW9uIC8+DQogICAgPFdhcmVob3VzZSBpZD0iMTU3Ij4NCiAgICAgIDxOYW1lPkhlYnJvbiwgS1k8L05hbWU+DQogICAgICA8QWRkcmVzcz4xMjAwIFdPUkxEV0lERSBCTFZEPC9BZGRyZXNzPg0KICAgICAgPENpdHk+SEVCUk9OPC9DaXR5Pg0KICAgICAgPFN0YXRlPktZPC9TdGF0ZT4NCiAgICAgIDxQb3N0YWxDb2RlPjQxMDQ4PC9Qb3N0YWxDb2RlPg0KICAgICAgPENvdW50cnk+VVM8L0NvdW50cnk+DQogICAgPC9XYXJlaG91c2U+DQogICAgPFNoaXBNZXRob2Q+SG9sZCwgRG8gIE5vdCBTaGlwPC9TaGlwTWV0aG9kPg0KICAgIDxTaGlwTWV0aG9kQ29kZT5IT0xEPC9TaGlwTWV0aG9kQ29kZT4NCiAgICA8VHJhY2tpbmcgLz4NCiAgICA8VHJhY2tpbmdVcmwgLz4NCiAgICA8V2VpZ2h0IC8+DQogICAgPFBvc3RhZ2UgLz4NCiAgICA8R2lmdFdyYXA+ZmFsc2U8L0dpZnRXcmFwPg0KICAgIDxDdXN0b21GaWVsZHM+DQogICAgICA8QWRkaXRpb25hbFRheD4xNS4wPC9BZGRpdGlvbmFsVGF4Pg0KICAgICAgPFN1YnRvdGFsPjEwLjA8L1N1YnRvdGFsPg0KICAgICAgPFRvdGFsPjI1LjA8L1RvdGFsPg0KICAgIDwvQ3VzdG9tRmllbGRzPg0KICAgIDxCYWNrb3JkZXJlZEl0ZW1zIC8+DQogICAgPEl0ZW1zIC8+DQogICAgPFBhY2thZ2VzIC8+DQogIDwvU2hpcG1lbnQ+DQogIDxTaGlwbWVudCBpZD0iOTE3NTUyNTQiPg0KICAgIDxDbGllbnROYW1lPlJvY2tldHMgb2YgQXdlc29tZTwvQ2xpZW50TmFtZT4NCiAgICA8T3JkZXJJRD5YTUwwMDE8L09yZGVySUQ+DQogICAgPFB1cmNoYXNlT3JkZXIgLz4NCiAgICA8TmFtZT5TVEVQSEVOIFNUUkFOR0U8L05hbWU+DQogICAgPEZpcnN0TmFtZT5TVEVQSEVOPC9GaXJzdE5hbWU+DQogICAgPExhc3ROYW1lPlNUUkFOR0U8L0xhc3ROYW1lPg0KICAgIDxDb21wYW55IC8+DQogICAgPEFkZHJlc3MxPjc1IFNQUklORyBTVCBGTCA0PC9BZGRyZXNzMT4NCiAgICA8QWRkcmVzczIgLz4NCiAgICA8Q2l0eT5ORVcgWU9SSzwvQ2l0eT4NCiAgICA8U3RhdGU+Tlk8L1N0YXRlPg0KICAgIDxQb3N0YWxDb2RlPjEwMDEyLTQwOTY8L1Bvc3RhbENvZGU+DQogICAgPENvdW50cnk+VU5JVEVEIFNUQVRFUzwvQ291bnRyeT4NCiAgICA8RW1haWw+c3RlcGhlbkBzdHJhbmdlLmNvbTwvRW1haWw+DQogICAgPFBob25lPjYxNyAxMjMgNDU2NzwvUGhvbmU+DQogICAgPE9yZGVyVGltZXN0YW1wPjIwMTctMDgtMjBUMDA6MDA6MDA8L09yZGVyVGltZXN0YW1wPg0KICAgIDxSZWNlaXZlZFRpbWVzdGFtcD4yMDE3LTA4LTIxVDA5OjE4OjU1LjEzMDwvUmVjZWl2ZWRUaW1lc3RhbXA+DQogICAgPFNoaXBtZW50U3RhdHVzPk9OSE9MRDwvU2hpcG1lbnRTdGF0dXM+DQogICAgPE9yZGVyVHlwZT5Db25zdW1lcjwvT3JkZXJUeXBlPg0KICAgIDxTaGlwcGVkRGF0ZSAvPg0KICAgIDxFeHBlY3RlZERlbGl2ZXJ5RGF0ZSAvPg0KICAgIDxEZWxpdmVyZWRUaW1lc3RhbXAgLz4NCiAgICA8RGVsaXZlcnlFeGNlcHRpb24gLz4NCiAgICA8V2FyZWhvdXNlIGlkPSIxNTciPg0KICAgICAgPE5hbWU+SGVicm9uLCBLWTwvTmFtZT4NCiAgICAgIDxBZGRyZXNzPjEyMDAgV09STERXSURFIEJMVkQ8L0FkZHJlc3M+DQogICAgICA8Q2l0eT5IRUJST048L0NpdHk+DQogICAgICA8U3RhdGU+S1k8L1N0YXRlPg0KICAgICAgPFBvc3RhbENvZGU+NDEwNDg8L1Bvc3RhbENvZGU+DQogICAgICA8Q291bnRyeT5VUzwvQ291bnRyeT4NCiAgICA8L1dhcmVob3VzZT4NCiAgICA8U2hpcE1ldGhvZD5Ib2xkLCBEbyAgTm90IFNoaXA8L1NoaXBNZXRob2Q+DQogICAgPFNoaXBNZXRob2RDb2RlPkhPTEQ8L1NoaXBNZXRob2RDb2RlPg0KICAgIDxUcmFja2luZyAvPg0KICAgIDxUcmFja2luZ1VybCAvPg0KICAgIDxXZWlnaHQgLz4NCiAgICA8UG9zdGFnZSAvPg0KICAgIDxHaWZ0V3JhcD5mYWxzZTwvR2lmdFdyYXA+DQogICAgPEN1c3RvbUZpZWxkcz4NCiAgICAgIDxBZGRpdGlvbmFsVGF4PjE1LjA8L0FkZGl0aW9uYWxUYXg+DQogICAgICA8U3VidG90YWw+MTAuMDwvU3VidG90YWw+DQogICAgICA8VG90YWw+MjUuMDwvVG90YWw+DQogICAgPC9DdXN0b21GaWVsZHM+DQogICAgPEJhY2tvcmRlcmVkSXRlbXMgLz4NCiAgICA8SXRlbXMgLz4NCiAgICA8UGFja2FnZXMgLz4NCiAgPC9TaGlwbWVudD4NCiAgPFNoaXBtZW50IGlkPSI5MTc1NTI1NSI+DQogICAgPENsaWVudE5hbWU+Um9ja2V0cyBvZiBBd2Vzb21lPC9DbGllbnROYW1lPg0KICAgIDxPcmRlcklEPlhNTDAwMTwvT3JkZXJJRD4NCiAgICA8UHVyY2hhc2VPcmRlciAvPg0KICAgIDxOYW1lIC8+DQogICAgPEZpcnN0TmFtZSAvPg0KICAgIDxMYXN0TmFtZSAvPg0KICAgIDxDb21wYW55IC8+DQogICAgPEFkZHJlc3MxIC8+DQogICAgPEFkZHJlc3MyIC8+DQogICAgPENpdHkgLz4NCiAgICA8U3RhdGUgLz4NCiAgICA8UG9zdGFsQ29kZSAvPg0KICAgIDxDb3VudHJ5IC8+DQogICAgPEVtYWlsIC8+DQogICAgPFBob25lIC8+DQogICAgPE9yZGVyVGltZXN0YW1wPjIwMTctMDgtMjBUMDA6MDA6MDA8L09yZGVyVGltZXN0YW1wPg0KICAgIDxSZWNlaXZlZFRpbWVzdGFtcD4yMDE3LTA4LTIxVDA5OjI2OjMxLjE2MDwvUmVjZWl2ZWRUaW1lc3RhbXA+DQogICAgPFNoaXBtZW50U3RhdHVzPk9OSE9MRDwvU2hpcG1lbnRTdGF0dXM+DQogICAgPE9yZGVyVHlwZT5Db25zdW1lcjwvT3JkZXJUeXBlPg0KICAgIDxTaGlwcGVkRGF0ZSAvPg0KICAgIDxFeHBlY3RlZERlbGl2ZXJ5RGF0ZSAvPg0KICAgIDxEZWxpdmVyZWRUaW1lc3RhbXAgLz4NCiAgICA8RGVsaXZlcnlFeGNlcHRpb24gLz4NCiAgICA8V2FyZWhvdXNlIGlkPSIxNTciPg0KICAgICAgPE5hbWU+SGVicm9uLCBLWTwvTmFtZT4NCiAgICAgIDxBZGRyZXNzPjEyMDAgV09STERXSURFIEJMVkQ8L0FkZHJlc3M+DQogICAgICA8Q2l0eT5IRUJST048L0NpdHk+DQogICAgICA8U3RhdGU+S1k8L1N0YXRlPg0KICAgICAgPFBvc3RhbENvZGU+NDEwNDg8L1Bvc3RhbENvZGU+DQogICAgICA8Q291bnRyeT5VUzwvQ291bnRyeT4NCiAgICA8L1dhcmVob3VzZT4NCiAgICA8U2hpcE1ldGhvZD5Ib2xkLCBEbyAgTm90IFNoaXA8L1NoaXBNZXRob2Q+DQogICAgPFNoaXBNZXRob2RDb2RlPkhPTEQ8L1NoaXBNZXRob2RDb2RlPg0KICAgIDxUcmFja2luZyAvPg0KICAgIDxUcmFja2luZ1VybCAvPg0KICAgIDxXZWlnaHQgLz4NCiAgICA8UG9zdGFnZSAvPg0KICAgIDxHaWZ0V3JhcD5mYWxzZTwvR2lmdFdyYXA+DQogICAgPEN1c3RvbUZpZWxkcz4NCiAgICAgIDxBZGRpdGlvbmFsVGF4PjE1LjA8L0FkZGl0aW9uYWxUYXg+DQogICAgICA8U3VidG90YWw+MTAuMDwvU3VidG90YWw+DQogICAgICA8VG90YWw+MjUuMDwvVG90YWw+DQogICAgPC9DdXN0b21GaWVsZHM+DQogICAgPEJhY2tvcmRlcmVkSXRlbXMgLz4NCiAgICA8SXRlbXMgLz4NCiAgICA8UGFja2FnZXMgLz4NCiAgPC9TaGlwbWVudD4NCjwvU2hpcG1lbnRzPg==
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <Shipments>
+          <Shipment id="91955463">
+            <ClientName>Rockets of Awesome</ClientName>
+            <OrderID>R123456789</OrderID>
+            <PurchaseOrder/>
+            <Name>MATT MURDOCK</Name>
+            <FirstName>MATT</FirstName>
+            <LastName>MURDOCK</LastName>
+            <Company/>
+            <Address1>75 SPRING ST FL 4</Address1>
+            <Address2/>
+            <City>NEW YORK</City>
+            <State>NY</State>
+            <PostalCode>10012-4096</PostalCode>
+            <Country>UNITED STATES</Country>
+            <Email>matt@murdock.com</Email>
+            <Phone>617 123 4567</Phone>
+            <OrderTimestamp>2017-09-05T00:00:00</OrderTimestamp>
+            <ReceivedTimestamp>2017-09-05T09:12:24.543</ReceivedTimestamp>
+            <ShipmentStatus>CANCELED</ShipmentStatus>
+            <OrderType>Consumer</OrderType>
+            <ShippedDate/>
+            <ExpectedDeliveryDate/>
+            <DeliveredTimestamp/>
+            <DeliveryException/>
+            <Warehouse id="157">
+              <Name>Hebron, KY</Name>
+              <Address>1200 WORLDWIDE BLVD</Address>
+              <City>HEBRON</City>
+              <State>KY</State>
+              <PostalCode>41048</PostalCode>
+              <Country>US</Country>
+            </Warehouse>
+            <ShipMethod>Hold, Do  Not Ship</ShipMethod>
+            <ShipMethodCode>HOLD</ShipMethodCode>
+            <Tracking/>
+            <TrackingUrl/>
+            <Weight/>
+            <Postage/>
+            <GiftWrap>false</GiftWrap>
+            <CustomFields>
+              <AdditionalTax>15.0</AdditionalTax>
+              <Subtotal>10.0</Subtotal>
+              <Total>25.0</Total>
+            </CustomFields>
+            <BackorderedItems/>
+            <Items>
+              <Item id="1484565">
+                <SKU>1007-201-G</SKU>
+                <UPC>1007-201-G</UPC>
+                <Description>WE ARE AWESOME TEE</Description>
+                <Lot/>
+                <Qty>1</Qty>
+                <CustomFields/>
+                <AssemblyItems/>
+              </Item>
+            </Items>
+            <Packages/>
+          </Shipment>
+          <Shipment id="91955506">
+            <ClientName>Rockets of Awesome</ClientName>
+            <OrderID>R123456789</OrderID>
+            <PurchaseOrder/>
+            <Name>STEPHEN STRANGE</Name>
+            <FirstName>STEPHEN</FirstName>
+            <LastName>STRANGE</LastName>
+            <Company/>
+            <Address1>75 SPRING ST FL 4</Address1>
+            <Address2/>
+            <City>NEW YORK</City>
+            <State>NY</State>
+            <PostalCode>10012-4096</PostalCode>
+            <Country>UNITED STATES</Country>
+            <Email>stephen@strange.com</Email>
+            <Phone>617 123 4567</Phone>
+            <OrderTimestamp>2017-08-20T00:00:00</OrderTimestamp>
+            <ReceivedTimestamp>2017-09-06T15:08:21.240</ReceivedTimestamp>
+            <ShipmentStatus>ONHOLD</ShipmentStatus>
+            <OrderType>Consumer</OrderType>
+            <ShippedDate/>
+            <ExpectedDeliveryDate/>
+            <DeliveredTimestamp/>
+            <DeliveryException/>
+            <Warehouse id="157">
+              <Name>Hebron, KY</Name>
+              <Address>1200 WORLDWIDE BLVD</Address>
+              <City>HEBRON</City>
+              <State>KY</State>
+              <PostalCode>41048</PostalCode>
+              <Country>US</Country>
+            </Warehouse>
+            <ShipMethod>Hold, Do  Not Ship</ShipMethod>
+            <ShipMethodCode>HOLD</ShipMethodCode>
+            <Tracking/>
+            <TrackingUrl/>
+            <Weight/>
+            <Postage/>
+            <GiftWrap>false</GiftWrap>
+            <CustomFields>
+              <AdditionalTax>15.0</AdditionalTax>
+              <Subtotal>10.0</Subtotal>
+              <Total>25.0</Total>
+            </CustomFields>
+            <BackorderedItems/>
+            <Items>
+              <Item id="1484565">
+                <SKU>1007-201-G</SKU>
+                <UPC>1007-201-G</UPC>
+                <Description>WE ARE AWESOME TEE</Description>
+                <Lot/>
+                <Qty>1</Qty>
+                <CustomFields/>
+                <AssemblyItems/>
+              </Item>
+              <Item id="1484566">
+                <SKU>1008-240-C</SKU>
+                <UPC>1008-240-C</UPC>
+                <Description>ESSENTIAL ZIP HOODIE</Description>
+                <Lot/>
+                <Qty>2</Qty>
+                <CustomFields>
+                  <GiftMessage>A sample message</GiftMessage>
+                </CustomFields>
+                <AssemblyItems/>
+              </Item>
+            </Items>
+            <Packages/>
+          </Shipment>
+        </Shipments>
     http_version:
-  recorded_at: Tue, 22 Aug 2017 20:16:34 GMT
+  recorded_at: Wed, 06 Sep 2017 21:08:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/shipment/where/successfully.yml
+++ b/spec/cassettes/shipment/where/successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://apistaging.newgisticsfulfillment.com/shipments.aspx?endReceivedTimestamp=2017-09-07&key=ABC123&startReceivedTimestamp=2017-08-01
+    uri: https://apistaging.newgisticsfulfillment.com/shipments.aspx?endReceivedTimestamp=2017-09-07&key=<API_KEY>&startReceivedTimestamp=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: 
     headers:
       cache-control:
       - private
@@ -21,14 +21,14 @@ http_interactions:
       server:
       - Microsoft-IIS/8.5
       set-cookie:
-      - ASP.NET_SessionId=qqojkowhl42dqzgaigjwoqgv; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+      - ASP.NET_SessionId=e2mmod4uwytivi5cmkag420x; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
         path=/
       x-aspnet-version:
       - 4.0.30319
       x-powered-by:
       - ASP.NET
       date:
-      - Wed, 06 Sep 2017 21:09:43 GMT
+      - Thu, 07 Sep 2017 13:20:25 GMT
       connection:
       - close
       content-length:
@@ -166,6 +166,6 @@ http_interactions:
             <Packages/>
           </Shipment>
         </Shipments>
-    http_version:
-  recorded_at: Wed, 06 Sep 2017 21:08:58 GMT
+    http_version: 
+  recorded_at: Thu, 07 Sep 2017 13:20:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/newgistics/inbound_return_spec.rb
+++ b/spec/newgistics/inbound_return_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Newgistics::InboundReturn do
 
         inbound_return.save
 
-        expect(inbound_return.id).to eq('1754251')
+        expect(inbound_return.id).to eq('1754253')
       end
     end
 
@@ -27,16 +27,7 @@ RSpec.describe Newgistics::InboundReturn do
     context "when the inbound return fails to save", vcr: vcr_options do
       it 'updates the inbound_return object with the errors' do
         inbound_return = Newgistics::InboundReturn.new(
-          shipment_id: '91755251',
-          rma: '12938474',
-          comments: 'Sample Comment',
-          items: [
-            Newgistics::Item.new(
-              sku: 'BCD-123',
-              qty: 2,
-              reason: 'Too Big'
-            )
-          ]
+          return_attributes(shipment_id: 'INVALID')
         )
 
         success = inbound_return.save
@@ -44,7 +35,7 @@ RSpec.describe Newgistics::InboundReturn do
         expect(success).to eq false
         expect(inbound_return.errors.size).to eq 1
         expect(inbound_return.errors.first).to eq(
-          "Unable to create inbound return; Product SKU BCD-123 was not found"
+          "Unable to create inbound return; invalid shipment ID."
         )
       end
     end
@@ -52,8 +43,8 @@ RSpec.describe Newgistics::InboundReturn do
 
   def return_attributes(overrides = {})
     {
-      shipment_id: '91955463',
-      rma: 'RMA_NUMBER',
+      shipment_id: '91955506',
+      rma: 'RA343167887',
       comments: 'Sample Comment',
       items: [
         {

--- a/spec/newgistics/order_spec.rb
+++ b/spec/newgistics/order_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Newgistics::Order do
     vcr_options = { cassette_name: 'order/save/successfully' }
     context "when the order is placed successfully", vcr: vcr_options do
       before { use_valid_api_key }
+
       it 'updates the order object with the shipment_id and any errors or warnings' do
         order = described_class.new(order_attributes)
 
@@ -22,7 +23,7 @@ RSpec.describe Newgistics::Order do
       end
     end
 
-    vcr_options = { cassette_name: 'order/save/failure' }
+    vcr_options = { cassette_name: 'order/save/failure', record: :new_episodes }
     context "when placing the order fails", vcr: vcr_options do
       before { use_invalid_api_key }
 
@@ -37,14 +38,14 @@ RSpec.describe Newgistics::Order do
 
         order.save
 
-        expect(order.errors).to include('Attribute "apiKey" empty or missing from "Orders" element.')
+        expect(order.errors).to include('Invalid API key')
       end
     end
   end
 
   def order_attributes(attributes = {})
     {
-      id: 'R123456789',
+      id: 'R987654321',
       ship_method: 'USPS Express',
       info_line: 'Additional order details',
       requires_signature: false,
@@ -53,15 +54,15 @@ RSpec.describe Newgistics::Order do
       hold_for_all_inventory: true,
       order_date: '2017-08-20',
       customer: {
-        first_name: 'Stephen',
-        last_name: 'Strange',
+        first_name: 'Wade',
+        last_name: 'Wilson',
         address1: '75 Spring St',
         address2: '4th Floor',
         city: 'New York',
         state: 'NY',
         zip: '10012',
         country: 'USA',
-        email: 'stephen@strange.com',
+        email: 'wade@wilson.com',
         phone: '617 123 4567',
         is_residential: false
       },

--- a/spec/newgistics/order_spec.rb
+++ b/spec/newgistics/order_spec.rb
@@ -44,9 +44,8 @@ RSpec.describe Newgistics::Order do
 
   def order_attributes(attributes = {})
     {
-      id: 'XML001',
-      warehouse_id: 'WAREHOUSE_ID',
-      ship_method: 'USPS',
+      id: 'R123456789',
+      ship_method: 'USPS Express',
       info_line: 'Additional order details',
       requires_signature: false,
       is_insured: false,
@@ -72,9 +71,9 @@ RSpec.describe Newgistics::Order do
         total: 25.0
       },
       items: [
-        { sku: 'SKU1', qty: 1, is_gift_wrapped: false },
+        { sku: '1007-201-G', qty: 1, is_gift_wrapped: false },
         {
-          sku: 'SKU2',
+          sku: '1008-240-C',
           qty: 2,
           is_gift_wrapped: true,
           custom_fields: {

--- a/spec/newgistics/order_spec.rb
+++ b/spec/newgistics/order_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Newgistics::Order do
       end
     end
 
-    vcr_options = { cassette_name: 'order/save/failure', record: :new_episodes }
+    vcr_options = { cassette_name: 'order/save/failure' }
     context "when placing the order fails", vcr: vcr_options do
       before { use_invalid_api_key }
 

--- a/spec/newgistics/product_spec.rb
+++ b/spec/newgistics/product_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Newgistics::Product do
           recalled_quantity: 0,
           current_quantity: 0,
           kitting_quantity: 0,
-          pending_quantity: 0,
-          available_quantity: 0
+          pending_quantity: 1,
+          available_quantity: -1
         )
       end
     end

--- a/spec/newgistics/shipment_spec.rb
+++ b/spec/newgistics/shipment_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe Newgistics::Shipment do
   include IntegrationHelpers
 
   describe '.where' do
-    vcr_options = { cassette_name: 'shipment/where/successfully' }
+    vcr_options = { cassette_name: 'shipment/where/successfully', record: :new_episodes }
     context "when the shipments are queried successfully", vcr: vcr_options do
       it 'returns a list of shipment objects' do
         use_valid_api_key
         start_date = Date.new(2017, 8, 1).iso8601
-        end_date = Date.new(2017, 8, 22).iso8601
+        end_date = Date.new(2017, 9, 7).iso8601
 
         results = Newgistics::Shipment.
           where(start_received_timestamp: start_date).
           where(end_received_timestamp: end_date).
           all
 
-        expect(results.length).to eql 6
-        expect(results.first).to have_attributes(
-          order_id: "XML001",
+        expect(results.length).to eql 2
+        expect(results.last).to have_attributes(
+          order_id: "R123456789",
           name: "STEPHEN STRANGE",
           first_name: "STEPHEN",
           last_name: "STRANGE",
@@ -30,7 +30,7 @@ RSpec.describe Newgistics::Shipment do
           email: "stephen@strange.com",
           phone: "617 123 4567",
           order_timestamp: DateTime.parse("2017-08-20T00:00:00"),
-          received_timestamp: DateTime.parse("2017-08-21T07:22:03.413"),
+          received_timestamp: DateTime.parse("2017-09-06T15:08:21"),
           shipment_status: "ONHOLD",
           order_type: "Consumer",
           shipment_date: nil,
@@ -40,7 +40,7 @@ RSpec.describe Newgistics::Shipment do
           ship_method_code:"HOLD",
           tracking: nil
         )
-        expect(results.first.warehouse).to have_attributes(
+        expect(results.last.warehouse).to have_attributes(
           id: "157",
           name: "Hebron, KY",
           address: "1200 WORLDWIDE BLVD",
@@ -49,7 +49,7 @@ RSpec.describe Newgistics::Shipment do
           postal_code: "41048",
           country: "US"
         )
-        expect(results.first.custom_fields).to include(
+        expect(results.last.custom_fields).to include(
           additional_tax: "15.0",
           subtotal: "10.0",
           total: "25.0"

--- a/spec/newgistics/shipment_spec.rb
+++ b/spec/newgistics/shipment_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Newgistics::Shipment do
   include IntegrationHelpers
 
   describe '.where' do
-    vcr_options = { cassette_name: 'shipment/where/successfully', record: :new_episodes }
+    vcr_options = { cassette_name: 'shipment/where/successfully' }
     context "when the shipments are queried successfully", vcr: vcr_options do
       it 'returns a list of shipment objects' do
         use_valid_api_key

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -1,9 +1,5 @@
 module IntegrationHelpers
   def use_valid_api_key
-    Newgistics.configuration.api_key = 'ABC123'
-  end
-
-  def use_real_api_key
     Newgistics.configuration.api_key = ENV['NEWGISTICS_API_KEY']
   end
 

--- a/spec/support/newgistics.rb
+++ b/spec/support/newgistics.rb
@@ -1,4 +1,3 @@
 Newgistics.configure do |config|
   config.host_url = "https://apistaging.newgisticsfulfillment.com"
-  config.api_key = "ABC123"
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,6 +9,8 @@ VCR.configure do |config|
     end
   end
 
+  config.filter_sensitive_data('<API_KEY>') { ENV['NEWGISTICS_API_KEY'] }
+
   config.default_cassette_options = {
     record: :none
   }

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -3,6 +3,12 @@ VCR.configure do |config|
   config.hook_into :faraday
   config.configure_rspec_metadata!
 
+  config.before_record do |i|
+    if i.response.headers['content-type'].include? "text/xml"
+      i.response.body = Nokogiri::XML(i.response.body).to_s
+    end
+  end
+
   config.default_cassette_options = {
     record: :none
   }


### PR DESCRIPTION
#### What's this PR do?
With this change we'll update all of our cassettes so we can actually read the body of the response, it was previously being recorded as a binary string which makes it harder for us to understand the expected outcome of our integration tests.

We'll also start automatically filtering our API key to ensure we don't commit sensitive information to the repository.