### PR TITLE
Update shipped date attribute on Shipments

### DIFF
--- a/lib/newgistics/shipment.rb
+++ b/lib/newgistics/shipment.rb
@@ -22,7 +22,7 @@ module Newgistics
     attribute :received_timestamp, DateTime
     attribute :shipment_status, String
     attribute :order_type, String
-    attribute :shipment_date, DateTime
+    attribute :shipped_date, DateTime
     attribute :expected_delivery_date, DateTime
     attribute :delivered_timestamp, DateTime
     attribute :warehouse, Warehouse

--- a/spec/newgistics/shipment_spec.rb
+++ b/spec/newgistics/shipment_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Newgistics::Shipment do
           received_timestamp: DateTime.parse("2017-09-06T15:08:21"),
           shipment_status: "ONHOLD",
           order_type: "Consumer",
-          shipment_date: nil,
+          shipped_date: nil,
           expected_delivery_date: nil,
           delivered_timestamp: nil,
           ship_method: "Hold, Do  Not Ship",


### PR DESCRIPTION
#### What's this PR do?
We used the wrong name for this attribute originally, the API returns `ShippedDate`, not `ShipmentDate`.