### PR TITLE
Add DropShipInfo attribute to Newgistics::Order

### DIFF
--- a/lib/newgistics/order.rb
+++ b/lib/newgistics/order.rb
@@ -5,6 +5,7 @@ module Newgistics
     attribute :id, String
     attribute :warehouse_id, String
     attribute :customer, Customer
+    attribute :drop_ship_info, Hash
     attribute :order_date, Date
     attribute :ship_method, String
     attribute :info_line, String

--- a/lib/newgistics/requests/post_shipment.rb
+++ b/lib/newgistics/requests/post_shipment.rb
@@ -47,6 +47,7 @@ module Newgistics
 
           order_date_xml(order, xml)
           customer_xml(order.customer, xml)
+          drop_ship_info_xml(order, xml)
           custom_fields_xml(order, xml)
           items_xml(order.items, xml)
         end
@@ -55,6 +56,14 @@ module Newgistics
       def order_date_xml(order, xml)
         unless order.order_date.nil?
           xml.OrderDate order.order_date.strftime('%m/%d/%Y')
+        end
+      end
+
+      def drop_ship_info_xml(object, xml)
+        xml.DropShipInfo do
+          object.drop_ship_info.each do |key, value|
+            xml.send StringHelper.camelize(key), value
+          end
         end
       end
 

--- a/spec/newgistics/requests/post_shipment_spec.rb
+++ b/spec/newgistics/requests/post_shipment_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Newgistics::Requests::PostShipment do
           phone: '617 123 4567',
           is_residential: false
         },
+        drop_ship_info: {
+          company_name: "Box",
+          address: "123 Broadway",
+          city: "New York",
+          state: "New York",
+          zip: "10012"
+        },
         custom_fields: {
           subtotal: 10.0,
           additional_tax: 15.0,
@@ -61,6 +68,7 @@ RSpec.describe Newgistics::Requests::PostShipment do
       verify_order_xml(xml.at_css('Order'))
       verify_customer_xml(xml.at_css('Order CustomerInfo'))
       verify_custom_fields_xml(xml.at_css('Order CustomFields'))
+      verify_drop_ship_info_xml(xml.at_css('Order DropShipInfo'))
       verify_items_xml(xml.at_css('Order Items'))
     end
 
@@ -96,6 +104,14 @@ RSpec.describe Newgistics::Requests::PostShipment do
       expect(custom_fields_xml).to have_element('Subtotal').with_text('10.0')
       expect(custom_fields_xml).to have_element('AdditionalTax').with_text('15.0')
       expect(custom_fields_xml).to have_element('Total').with_text('25.0')
+    end
+
+    def verify_drop_ship_info_xml(drop_ship_info_xml)
+      expect(drop_ship_info_xml).to have_element('CompanyName').with_text('Box')
+      expect(drop_ship_info_xml).to have_element('Address').with_text('123 Broadway')
+      expect(drop_ship_info_xml).to have_element('City').with_text('New York')
+      expect(drop_ship_info_xml).to have_element('State').with_text('New York')
+      expect(drop_ship_info_xml).to have_element('Zip').with_text('10012')
     end
 
     def verify_items_xml(items_xml)


### PR DESCRIPTION
#### What does this PR do?
Update the `Newgistics::Order` class to allow for DropShipInfo fields. This will allow us to send specialized messages such as the type of order.