### PR TITLE
Add the tracking_url attribute to Shipments

### DIFF
--- a/lib/newgistics/shipment.rb
+++ b/lib/newgistics/shipment.rb
@@ -29,6 +29,7 @@ module Newgistics
     attribute :ship_method, String
     attribute :ship_method_code, String
     attribute :tracking, String
+    attribute :tracking_url, String
     attribute :items, Array[Item]
     attribute :custom_fields, Hash
 

--- a/spec/cassettes/shipment/where/successfully.yml
+++ b/spec/cassettes/shipment/where/successfully.yml
@@ -12,7 +12,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       cache-control:
       - private
@@ -130,8 +130,8 @@ http_interactions:
             </Warehouse>
             <ShipMethod>Hold, Do  Not Ship</ShipMethod>
             <ShipMethodCode>HOLD</ShipMethodCode>
-            <Tracking/>
-            <TrackingUrl/>
+            <Tracking>4209492592612927005053140000004149</Tracking>
+            <TrackingUrl>http://shipment.co/tracking/2544/4209492592612927005053140000004149</TrackingUrl>
             <Weight/>
             <Postage/>
             <GiftWrap>false</GiftWrap>
@@ -166,6 +166,6 @@ http_interactions:
             <Packages/>
           </Shipment>
         </Shipments>
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Sep 2017 13:20:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/newgistics/shipment_spec.rb
+++ b/spec/newgistics/shipment_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Newgistics::Shipment do
           delivered_timestamp: nil,
           ship_method: "Hold, Do  Not Ship",
           ship_method_code:"HOLD",
-          tracking: nil
+          tracking: '4209492592612927005053140000004149',
+          tracking_url: 'http://shipment.co/tracking/2544/4209492592612927005053140000004149'
         )
         expect(results.last.warehouse).to have_attributes(
           id: "157",


### PR DESCRIPTION
#### What's this PR do?
Newgistics provides a tracking URL along with the tracking number for shipped shipments, this information can come in handy for developers so we'll expose it.