### PR TITLE
Log requests made to Newgistics

### DIFF
--- a/lib/newgistics.rb
+++ b/lib/newgistics.rb
@@ -4,6 +4,7 @@ require "faraday"
 require "tzinfo"
 
 require "newgistics/api"
+require "newgistics/default_logger"
 require "newgistics/configuration"
 require "newgistics/time_zone"
 require "newgistics/timestamp"
@@ -39,6 +40,14 @@ module Newgistics
 
   def self.api
     @api ||= Api.new
+  end
+
+  def self.logger
+    @logger ||= DefaultLogger.build
+  end
+
+  def self.logger=(logger)
+    @logger = logger
   end
 
   def self.time_zone

--- a/lib/newgistics/api.rb
+++ b/lib/newgistics/api.rb
@@ -13,7 +13,9 @@ module Newgistics
     private
 
     def connection
-      @connection ||= Faraday.new(url: host_url)
+      @connection ||= Faraday.new(url: host_url) do |faraday|
+        faraday.response :logger, Newgistics.logger, bodies: true
+      end
     end
 
     def host_url

--- a/lib/newgistics/default_logger.rb
+++ b/lib/newgistics/default_logger.rb
@@ -1,0 +1,11 @@
+require 'logger'
+
+module Newgistics
+  class DefaultLogger
+    def self.build
+      Logger.new(STDOUT).tap do |logger|
+        logger.level = Logger::INFO
+      end
+    end
+  end
+end

--- a/spec/newgistics/default_logger_spec.rb
+++ b/spec/newgistics/default_logger_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Newgistics::DefaultLogger do
+  describe '.build' do
+    it "returns a new Logger with the right log level" do
+      logger = described_class.build
+
+      expect(logger).to be_info
+    end
+  end
+end

--- a/spec/newgistics_spec.rb
+++ b/spec/newgistics_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe Newgistics do
     expect(Newgistics.configuration).not_to be_nil
   end
 
+  describe '.logger=' do
+    it "allows developers to override the logger" do
+      logger = Logger.new(File::NULL)
+
+      Newgistics.logger = logger
+
+      expect(Newgistics.logger).to eq(logger)
+    end
+  end
+
   describe '.configure' do
     it "sets configuration options for Newgistics" do
       Newgistics.configure do |config|

--- a/spec/support/newgistics.rb
+++ b/spec/support/newgistics.rb
@@ -1,3 +1,6 @@
 Newgistics.configure do |config|
   config.host_url = "https://apistaging.newgisticsfulfillment.com"
 end
+
+Newgistics.logger.level = Logger::FATAL
+


### PR DESCRIPTION
#### What's this PR do?
With this change we'll introduce the `Newgistics.logger` which will log every request made to Newgistics by leveraging the response middleware from Faraday.

Developers can easily configure logging options by accessing the logger through the Newgistics module. For example, if they need to change the log level to DEBUG, they can simply do:

```ruby
Newgistics.logger.log_level = Logger::DEBUG
```

They can also override the logger completely by using the `logger=` method:

```ruby
Newgistics.logger = Logger.new(filename)
```