### PR TITLE
Remove usage of reason_phrase to support Faraday 0.9

### DIFF
--- a/lib/newgistics/response_handlers/post_errors.rb
+++ b/lib/newgistics/response_handlers/post_errors.rb
@@ -24,9 +24,7 @@ module Newgistics
       end
 
       def handle_failed_response(response)
-        message = "Failed to save model: "
-        message += "#{response.status} - #{response.reason_phrase}"
-
+        message = "API Error: #{response.status}"
         model.errors << message
       end
 

--- a/lib/newgistics/response_handlers/search.rb
+++ b/lib/newgistics/response_handlers/search.rb
@@ -42,7 +42,7 @@ module Newgistics
       end
 
       def handle_failed_response(response)
-        raise_error "#{response.status} - #{response.reason_phrase}"
+        raise_error "API Error: #{response.status}"
       end
 
       def raise_error(message)

--- a/spec/newgistics/response_handlers/post_errors_spec.rb
+++ b/spec/newgistics/response_handlers/post_errors_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Newgistics::ResponseHandlers::PostErrors do
 
     it 'handles a 404 response' do
       bogus_model = Newgistics::BogusModel.new
-      response = build_response(status: 404, reason_phrase: 'Not Found')
+      response = build_response(status: 404)
       response_handler = described_class.new(bogus_model)
 
       response_handler.handle(response)
 
       expect(bogus_model.errors.length).to eq 1
-      expect(bogus_model.errors.first).to eq "Failed to save model: 404 - Not Found"
+      expect(bogus_model.errors.first).to eq "API Error: 404"
     end
   end
 end

--- a/spec/newgistics/response_handlers/search_spec.rb
+++ b/spec/newgistics/response_handlers/search_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Newgistics::ResponseHandlers::Search do
 
     context "when the response has a failure HTTP status" do
       it "raises a Newgistics::QueryError" do
-        response = build_response(status: 404, reason_phrase: 'Not Found')
+        response = build_response(status: 404)
         response_handler = build_response_handler
 
         expect { response_handler.handle(response) }.


### PR DESCRIPTION
#### What's this PR do?
Faraday introduced the `Faraday::Response#reason_phrase` method on v0.10, in order to support Faraday v0.9.x, we'll stop using it.

In case developers need more details on why their request is failing they can just set the logger level to DEBUG.