### PR TITLE
Make sure we use an adapter for our faraday connection

### DIFF
--- a/lib/newgistics/api.rb
+++ b/lib/newgistics/api.rb
@@ -15,6 +15,7 @@ module Newgistics
     def connection
       @connection ||= Faraday.new(url: host_url) do |faraday|
         faraday.response :logger, Newgistics.logger, bodies: true
+        faraday.adapter Faraday.default_adapter
       end
     end
 


### PR DESCRIPTION
#### What's this PR do?
When adding middleware to the faraday connection we need to be explicit about which adapter we'll use, otherwise no HTTP requests are actually made.

Sadly, Faraday doesn't raise an exception if the adapter is missing and you end up debugging cryptic error messages raised from the middleware :panda_face:

For more information see: https://github.com/lostisland/faraday/issues/317