### PR TITLE
Send the AllowDuplicate tag when posting shipments

### DIFF
--- a/lib/newgistics/order.rb
+++ b/lib/newgistics/order.rb
@@ -16,6 +16,7 @@ module Newgistics
     attribute :gift_message, String
     attribute :hold_for_all_inventory, Boolean
     attribute :custom_fields, Hash
+    attribute :allow_duplicate, Boolean
     attribute :items, Array[Item]
 
     attribute :errors, Array[String], default: []

--- a/lib/newgistics/requests/post_shipment.rb
+++ b/lib/newgistics/requests/post_shipment.rb
@@ -44,6 +44,7 @@ module Newgistics
           xml.AddGiftWrap order.add_gift_wrap
           xml.GiftMessage order.gift_message
           xml.HoldForAllInventory order.hold_for_all_inventory
+          xml.AllowDuplicate order.allow_duplicate
 
           order_date_xml(order, xml)
           customer_xml(order.customer, xml)

--- a/spec/newgistics/requests/post_shipment_spec.rb
+++ b/spec/newgistics/requests/post_shipment_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Newgistics::Requests::PostShipment do
         is_insured: false,
         add_gift_wrap: false,
         hold_for_all_inventory: true,
+        allow_duplicate: false,
         order_date: '2017-08-20',
         customer: {
           first_name: 'Stephen',
@@ -84,6 +85,7 @@ RSpec.describe Newgistics::Requests::PostShipment do
       expect(order_xml).to have_element('AddGiftWrap').with_text('false')
       expect(order_xml).to have_element('HoldForAllInventory').with_text('true')
       expect(order_xml).to have_element('OrderDate').with_text('08/20/2017')
+      expect(order_xml).to have_element('AllowDuplicate').with_text('false')
     end
 
     def verify_customer_xml(customer_xml)


### PR DESCRIPTION
#### What's this PR do?
With this change we'll add the `allow_duplicate` attribute to the `Newgistics::Order` so developers can send it when posting orders to Newgistics.