### PR TITLE
Refactor Post Requests

### DIFF
--- a/lib/newgistics/inbound_return.rb
+++ b/lib/newgistics/inbound_return.rb
@@ -13,10 +13,7 @@ module Newgistics
     attribute :warnings, Array[String]
 
     def save
-      request = Requests::PostInboundReturn.new([self])
-      response_handler = ResponseHandlers::PostInboundReturn.new(self)
-
-      Newgistics.api.post(request, response_handler)
+      request = Requests::PostInboundReturn.new(self).perform
 
       errors.empty?
     end

--- a/lib/newgistics/inbound_return.rb
+++ b/lib/newgistics/inbound_return.rb
@@ -13,7 +13,7 @@ module Newgistics
     attribute :warnings, Array[String]
 
     def save
-      request = Requests::PostInboundReturn.new(self).perform
+      Requests::PostInboundReturn.new(self).perform
 
       errors.empty?
     end

--- a/lib/newgistics/order.rb
+++ b/lib/newgistics/order.rb
@@ -24,10 +24,7 @@ module Newgistics
     attribute :shipment_id, String
 
     def save
-      request = Requests::PostShipment.new([self])
-      response_handler = ResponseHandlers::PostShipment.new(self)
-
-      Newgistics.api.post(request, response_handler)
+      request = Requests::PostShipment.new(self).perform
 
       errors.empty?
     end

--- a/lib/newgistics/order.rb
+++ b/lib/newgistics/order.rb
@@ -24,7 +24,7 @@ module Newgistics
     attribute :shipment_id, String
 
     def save
-      request = Requests::PostShipment.new(self).perform
+      Requests::PostShipment.new(self).perform
 
       errors.empty?
     end

--- a/lib/newgistics/requests/cancel_shipment.rb
+++ b/lib/newgistics/requests/cancel_shipment.rb
@@ -1,10 +1,11 @@
 module Newgistics
   module Requests
     class CancelShipment
-      attr_reader :shipment_cancellation
+      attr_reader :shipment_cancellation, :response_handler
 
-      def initialize(shipment_cancellation)
+      def initialize(shipment_cancellation, response_handler: nil)
         @shipment_cancellation = shipment_cancellation
+        @response_handler = response_handler || default_response_handler
       end
 
       def path
@@ -15,7 +16,15 @@ module Newgistics
         xml_builder.to_xml
       end
 
+      def perform
+        Newgistics.api.post(self, response_handler.new(shipment_cancellation))
+      end
+
       private
+
+      def default_response_handler
+        ResponseHandlers::CancelShipment
+      end
 
       def xml_builder
         Nokogiri::XML::Builder.new do |xml|

--- a/lib/newgistics/requests/cancel_shipment.rb
+++ b/lib/newgistics/requests/cancel_shipment.rb
@@ -17,13 +17,13 @@ module Newgistics
       end
 
       def perform
-        Newgistics.api.post(self, response_handler.new(shipment_cancellation))
+        Newgistics.api.post(self, response_handler)
       end
 
       private
 
       def default_response_handler
-        ResponseHandlers::CancelShipment
+        ResponseHandlers::CancelShipment.new(shipment_cancellation)
       end
 
       def xml_builder

--- a/lib/newgistics/requests/post_inbound_return.rb
+++ b/lib/newgistics/requests/post_inbound_return.rb
@@ -17,13 +17,13 @@ module Newgistics
       end
 
       def perform
-        Newgistics.api.post(self, response_handler.new(inbound_return))
+        Newgistics.api.post(self, response_handler)
       end
 
       private
 
       def default_response_handler
-        ResponseHandlers::PostInboundReturn
+        ResponseHandlers::PostInboundReturn.new(inbound_return)
       end
 
       def xml_builder

--- a/lib/newgistics/requests/post_inbound_return.rb
+++ b/lib/newgistics/requests/post_inbound_return.rb
@@ -1,10 +1,11 @@
 module Newgistics
   module Requests
     class PostInboundReturn
-      attr_reader :returns
+      attr_reader :inbound_return, :response_handler
 
-      def initialize(returns)
-        @returns = returns
+      def initialize(inbound_return, response_handler: nil)
+        @inbound_return = inbound_return
+        @response_handler = response_handler || default_response_handler
       end
 
       def path
@@ -15,7 +16,15 @@ module Newgistics
         xml_builder.to_xml
       end
 
+      def perform
+        Newgistics.api.post(self, response_handler.new(inbound_return))
+      end
+
       private
+
+      def default_response_handler
+        ResponseHandlers::PostInboundReturn
+      end
 
       def xml_builder
         Nokogiri::XML::Builder.new do |xml|
@@ -25,7 +34,7 @@ module Newgistics
 
       def returns_xml(xml)
         xml.Returns(apiKey: api_key) do
-          returns.each { |inbound_return| return_xml(inbound_return, xml) }
+          return_xml(inbound_return, xml)
         end
       end
 

--- a/lib/newgistics/requests/post_shipment.rb
+++ b/lib/newgistics/requests/post_shipment.rb
@@ -17,13 +17,13 @@ module Newgistics
       end
 
       def perform
-        Newgistics.api.post(self, response_handler.new(order))
+        Newgistics.api.post(self, response_handler)
       end
 
       private
 
       def default_response_handler
-        ResponseHandlers::PostShipment
+        ResponseHandlers::PostShipment.new(order)
       end
 
       def xml_builder

--- a/lib/newgistics/requests/post_shipment.rb
+++ b/lib/newgistics/requests/post_shipment.rb
@@ -1,10 +1,11 @@
 module Newgistics
   module Requests
     class PostShipment
-      attr_reader :orders
+      attr_reader :order, :response_handler
 
-      def initialize(orders)
-        @orders = orders
+      def initialize(order, response_handler: nil)
+        @order = order
+        @response_handler = response_handler || default_response_handler
       end
 
       def path
@@ -15,7 +16,15 @@ module Newgistics
         xml_builder.to_xml
       end
 
+      def perform
+        Newgistics.api.post(self, response_handler.new(order))
+      end
+
       private
+
+      def default_response_handler
+        ResponseHandlers::PostShipment
+      end
 
       def xml_builder
         Nokogiri::XML::Builder.new do |xml|
@@ -25,7 +34,7 @@ module Newgistics
 
       def orders_xml(xml)
         xml.Orders(apiKey: api_key) do
-          orders.each { |order| order_xml(order, xml) }
+          order_xml(order, xml)
         end
       end
 

--- a/lib/newgistics/requests/update_shipment_contents.rb
+++ b/lib/newgistics/requests/update_shipment_contents.rb
@@ -17,13 +17,13 @@ module Newgistics
       end
 
       def perform
-        Newgistics.api.post(self, response_handler.new(shipment_update))
+        Newgistics.api.post(self, response_handler)
       end
 
       private
 
       def default_response_handler
-        ResponseHandlers::UpdateShipmentContents
+        ResponseHandlers::UpdateShipmentContents.new(shipment_update)
       end
 
       def xml_builder

--- a/lib/newgistics/requests/update_shipment_contents.rb
+++ b/lib/newgistics/requests/update_shipment_contents.rb
@@ -1,10 +1,11 @@
 module Newgistics
   module Requests
     class UpdateShipmentContents
-      attr_reader :shipment_update
+      attr_reader :shipment_update, :response_handler
 
-      def initialize(shipment_update)
+      def initialize(shipment_update, response_handler: nil)
         @shipment_update = shipment_update
+        @response_handler = response_handler || default_response_handler
       end
 
       def path
@@ -15,7 +16,15 @@ module Newgistics
         xml_builder.to_xml
       end
 
+      def perform
+        Newgistics.api.post(self, response_handler.new(shipment_update))
+      end
+
       private
+
+      def default_response_handler
+        ResponseHandlers::UpdateShipmentContents
+      end
 
       def xml_builder
         Nokogiri::XML::Builder.new do |xml|

--- a/lib/newgistics/shipment_cancellation.rb
+++ b/lib/newgistics/shipment_cancellation.rb
@@ -16,10 +16,7 @@ module Newgistics
     end
 
     def save
-      request = Requests::CancelShipment.new(self)
-      response_handler = ResponseHandlers::CancelShipment.new(self)
-
-      Newgistics.api.post(request, response_handler)
+      request = Requests::CancelShipment.new(self).perform
 
       errors.empty? && success?
     end

--- a/lib/newgistics/shipment_cancellation.rb
+++ b/lib/newgistics/shipment_cancellation.rb
@@ -16,7 +16,7 @@ module Newgistics
     end
 
     def save
-      request = Requests::CancelShipment.new(self).perform
+      Requests::CancelShipment.new(self).perform
 
       errors.empty? && success?
     end

--- a/lib/newgistics/shipment_update.rb
+++ b/lib/newgistics/shipment_update.rb
@@ -16,10 +16,7 @@ module Newgistics
     end
 
     def save
-      request = Requests::UpdateShipmentContents.new(self)
-      response_handler = ResponseHandlers::UpdateShipmentContents.new(self)
-
-      Newgistics.api.post(request, response_handler)
+      request = Requests::UpdateShipmentContents.new(self).perform
 
       errors.empty? && success?
     end

--- a/lib/newgistics/shipment_update.rb
+++ b/lib/newgistics/shipment_update.rb
@@ -16,7 +16,7 @@ module Newgistics
     end
 
     def save
-      request = Requests::UpdateShipmentContents.new(self).perform
+      Requests::UpdateShipmentContents.new(self).perform
 
       errors.empty? && success?
     end

--- a/spec/newgistics/requests/post_inbound_return_spec.rb
+++ b/spec/newgistics/requests/post_inbound_return_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Newgistics::Requests::PostInboundReturn do
           )
         ]
       )
-      request = described_class.new([inbound_return])
+      request = described_class.new(inbound_return)
 
       xml = Nokogiri::XML(request.body)
 

--- a/spec/newgistics/requests/post_shipment_spec.rb
+++ b/spec/newgistics/requests/post_shipment_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Newgistics::Requests::PostShipment do
           }
         ]
       )
-      request = described_class.new([order])
+      request = described_class.new(order)
 
       xml = Nokogiri::XML(request.body)
 


### PR DESCRIPTION
#### What does this PR do?
Refactor the post requests to Newgistics to use a new format where each request knows the response_handler and type of request to send. This should cut down on repetition and better abstract our code