### PR TITLE
Add predicate methods to check shipment status

### DIFF
--- a/lib/newgistics/shipment.rb
+++ b/lib/newgistics/shipment.rb
@@ -33,6 +33,38 @@ module Newgistics
     attribute :items, Array[Item]
     attribute :custom_fields, Hash
 
+    def backordered?
+      shipment_status == 'BACKORDER'
+    end
+
+    def canceled?
+      shipment_status == 'CANCELED'
+    end
+
+    def on_hold?
+      %w(ONHOLD BADSKUHOLD BADADDRESS CNFHOLD INVHOLD).include? shipment_status
+    end
+
+    def received?
+      shipment_status == 'RECEIVED'
+    end
+
+    def printed?
+      shipment_status == 'PRINTED'
+    end
+
+    def shipped?
+      shipment_status == 'SHIPPED'
+    end
+
+    def returned?
+      shipment_status == 'RETURNED'
+    end
+
+    def verified?
+      shipment_status == 'VERIFIED'
+    end
+
     def self.where(conditions)
       Query.build(
         endpoint: '/shipments.aspx',

--- a/spec/newgistics/shipment_spec.rb
+++ b/spec/newgistics/shipment_spec.rb
@@ -69,4 +69,118 @@ RSpec.describe Newgistics::Shipment do
       end
     end
   end
+
+  describe '#backordered?' do
+    it "returns true for backordered shipments" do
+      shipment = described_class.new(shipment_status: 'BACKORDER')
+
+      expect(shipment).to be_backordered
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'SHIPPED')
+
+      expect(shipment).not_to be_backordered
+    end
+  end
+
+  describe '#canceled?' do
+    it "returns true for canceled shipments" do
+      shipment = described_class.new(shipment_status: 'CANCELED')
+
+      expect(shipment).to be_canceled
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'SHIPPED')
+
+      expect(shipment).not_to be_canceled
+    end
+  end
+
+  describe '#on_hold?' do
+    %w(BADADDRESS ONHOLD BADSKUHOLD CNFHOLD INVHOLD).each do |status|
+      it "returns true for shipments with a #{status} status" do
+        shipment = described_class.new(shipment_status: status)
+
+        expect(shipment).to be_on_hold
+      end
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'SHIPPED')
+
+      expect(shipment).not_to be_on_hold
+    end
+  end
+
+  describe '#received?' do
+    it "returns true for received shipments" do
+      shipment = described_class.new(shipment_status: 'RECEIVED')
+
+      expect(shipment).to be_received
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'SHIPPED')
+
+      expect(shipment).not_to be_received
+    end
+  end
+
+  describe '#printed?' do
+    it "returns true for printed shipments" do
+      shipment = described_class.new(shipment_status: 'PRINTED')
+
+      expect(shipment).to be_printed
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'SHIPPED')
+
+      expect(shipment).not_to be_printed
+    end
+  end
+
+  describe '#shipped?' do
+    it "returns true for shipped shipments" do
+      shipment = described_class.new(shipment_status: 'SHIPPED')
+
+      expect(shipment).to be_shipped
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'CANCELED')
+
+      expect(shipment).not_to be_shipped
+    end
+  end
+
+  describe '#returned?' do
+    it "returns true for returned shipments" do
+      shipment = described_class.new(shipment_status: 'RETURNED')
+
+      expect(shipment).to be_returned
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'BACKORDER')
+
+      expect(shipment).not_to be_returned
+    end
+  end
+
+  describe '#verified?' do
+    it "returns true for verified shipments" do
+      shipment = described_class.new(shipment_status: 'VERIFIED')
+
+      expect(shipment).to be_verified
+    end
+
+    it "returns false for any other shipment_status" do
+      shipment = described_class.new(shipment_status: 'SHIPPED')
+
+      expect(shipment).not_to be_verified
+    end
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
With this change we'll add a couple of convenience methods that easily allow developers to check whether a shipment is in a certain status or not.