### PR TITLE
Allow developers to query inbound returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And then execute:
     $ bundle
 
 ## Configuration
-Below is the available configuration options and their default values
+Here is a list of the available configuration options and their default values
 
 | Option          | Description                                                                                                                                                                                                                                                | Default Value                                |
 |-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
@@ -108,6 +108,19 @@ Newgistics::InboundReturn.new(inbound_return_attributes).save
 `inbound_return_attributes` is a `Hash` containing all the attributes for the inbound return, the attributes should map one-to-one to the Newgistics API spec. *Caveat*: you should only supply either `shipment_id` or `order_id` but not both because you will receive an error from the API.
 
 `inbound_return.save` will return `true` if the inbound return is sent successfully to Newgistics and `false` otherwise, any errors or warnings generated when sending the inbound_return are available under `inbound_return.errors` and `inbound_return.warnings` respectively
+
+#### Searching for inbound returns on Newgistics
+
+```ruby
+Newgistics::InboundReturn.
+  where(start_created_timestamp: start_date).
+  where(end_created_timestamp: end_date).
+  all
+```
+
+You can use the `where` method to specify the parameters of the Search. Parameter keys will be automatically camelized when sent to Newgistics, for a full list of the available parameters refer to the Newgistics API documentation.
+
+`Newgistics::InboundReturn.where(conditions).all` will return a list of `Newgistics::InboundReturn` elements if the request is successful. Otherwise it will raise a `Newgistics::QueryError`.
 
 ### Returns
 

--- a/lib/newgistics/inbound_return.rb
+++ b/lib/newgistics/inbound_return.rb
@@ -12,6 +12,14 @@ module Newgistics
     attribute :errors, Array[String]
     attribute :warnings, Array[String]
 
+    def self.where(conditions)
+      Query.build(
+        endpoint: '/inbound_returns.aspx',
+        element_selector: 'InboundReturns InboundReturn',
+        model_class: self
+      ).where(conditions)
+    end
+
     def save
       Requests::PostInboundReturn.new(self).perform
 

--- a/lib/newgistics/response_handlers/search.rb
+++ b/lib/newgistics/response_handlers/search.rb
@@ -20,13 +20,17 @@ module Newgistics
 
       def handle_successful_response(response)
         xml = Nokogiri::XML(response.body)
-        errors = xml.css('errors error').map(&:text)
+        errors = error_nodes(xml).map(&:text)
 
         if errors.empty?
           build_models(xml)
         else
           raise_error(errors.join(', '))
         end
+      end
+
+      def error_nodes(xml)
+        xml.css('errors error') + xml.css('Errors Error')
       end
 
       def build_models(xml)

--- a/spec/cassettes/inbound_return/where/error.yml
+++ b/spec/cassettes/inbound_return/where/error.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://apistaging.newgisticsfulfillment.com/inbound_returns.aspx?key=INVALID&shipmentId=92978955
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      cache-control:
+      - private
+      content-type:
+      - text/xml
+      server:
+      - Microsoft-IIS/8.5
+      set-cookie:
+      - ASP.NET_SessionId=u1za44sjuerhtx1ej0mt2iln; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+        path=/
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      date:
+      - Thu, 09 Nov 2017 00:04:18 GMT
+      connection:
+      - close
+      content-length:
+      - '139'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <InboundReturns>
+          <Errors>
+            <Error>Invalid API key</Error>
+          </Errors>
+        </InboundReturns>
+    http_version: 
+  recorded_at: Thu, 09 Nov 2017 00:04:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/inbound_return/where/success.yml
+++ b/spec/cassettes/inbound_return/where/success.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://apistaging.newgisticsfulfillment.com/inbound_returns.aspx?endCreatedTimestamp=2017-11-09&key=<API_KEY>&startCreatedTimestamp=2017-11-07
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      cache-control:
+      - private
+      content-type:
+      - text/xml
+      server:
+      - Microsoft-IIS/8.5
+      set-cookie:
+      - ASP.NET_SessionId=y5tbys3chcjgfg1mxdccfn1x; path=/; HttpOnly, NgsFulLB=rd3o00000000000000000000ffffac1f173do80;
+        path=/
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      date:
+      - Thu, 09 Nov 2017 00:00:03 GMT
+      connection:
+      - close
+      content-length:
+      - '951'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <InboundReturns>
+          <InboundReturn id="1799569">
+            <ShipmentID>92978955</ShipmentID>
+            <OrderID>R041850832</OrderID>
+            <RMA>RA123456789</RMA>
+            <CreateTimestamp>2017-11-08T16:58:21.817</CreateTimestamp>
+            <FirstName>JENNIFER</FirstName>
+            <LastName>USREY</LastName>
+            <Company>ATTN: ELLA</Company>
+            <Address1>10 ROCK HAVEN LN </Address1>
+            <Address2/>
+            <City>SIGNAL MOUNTAIN</City>
+            <State>TN</State>
+            <PostalCode>37377-2133</PostalCode>
+            <Country>UNITED STATES</Country>
+            <Email>jmusrey@yahoo.com</Email>
+            <Phone/>
+            <LabelUrl/>
+            <SmartLabelTracking/>
+            <CarrierTracking/>
+            <Items>
+              <Item id="1490831">
+                <SKU>5257-525-P</SKU>
+                <Description>SPLIT BACK ACTIVE TOP SUGAR PLUM</Description>
+                <Qty>1</Qty>
+                <Reason>Box Returns</Reason>
+              </Item>
+            </Items>
+          </InboundReturn>
+        </InboundReturns>
+    http_version: 
+  recorded_at: Thu, 09 Nov 2017 00:00:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/newgistics/inbound_return_spec.rb
+++ b/spec/newgistics/inbound_return_spec.rb
@@ -3,6 +3,46 @@ require 'spec_helper'
 RSpec.describe Newgistics::InboundReturn do
   include IntegrationHelpers
 
+  describe '.where' do
+    vcr_options = { cassette_name: 'inbound_return/where/success' }
+    context "when the api is queried successfully", vcr: vcr_options do
+      it "returns an array of inbound returns" do
+        use_valid_api_key
+        start_date = Date.new(2017, 11, 7).iso8601
+        end_date = Date.new(2017, 11, 9).iso8601
+
+        results = Newgistics::InboundReturn.
+          where(start_created_timestamp: start_date).
+          where(end_created_timestamp: end_date).
+          all
+
+        inbound_return = results.first
+        expect(results.size).to eq(1)
+        expect(inbound_return).to have_attributes(
+          id: '1799569',
+          shipment_id: '92978955',
+          order_id: 'R041850832',
+          rma: 'RA123456789'
+        )
+        expect(inbound_return.items.first).to have_attributes(
+          sku: '5257-525-P',
+          qty: 1,
+          reason: 'Box Returns'
+        )
+      end
+    end
+
+    vcr_options = { cassette_name: 'inbound_return/where/error', record: :new_episodes }
+    context "when there's an error querying the api", vcr: vcr_options do
+      it "raises a QueryError" do
+        use_invalid_api_key
+
+        expect { Newgistics::InboundReturn.where(shipment_id: '92978955').first }.
+          to raise_error(Newgistics::QueryError)
+      end
+    end
+  end
+
   describe '#save' do
     before { use_valid_api_key }
 


### PR DESCRIPTION
#### What's this PR do?
With this change we'll allow developers to query for created inbound returns by using the where method on the `Newgistics::InboundReturn` class:

```ruby
Newgistics::InboundReturn.where(shipment_id: '912349').first
```

Like we do with other models in the gem, the where method builds a `Query` object that is sent to the `/inbound_returns.aspx` endpoint.