### PR TITLE
Rename host_url to api_base_url

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,8 +1,0 @@
-require "pry"
-require "dotenv"
-Dotenv.load
-
-Newgistics.configure do |config|
-  config.host_url = ENV.fetch('NEWGISTICS_API_URL', "https://apistaging.newgisticsfulfillment.com")
-  config.api_key = ENV['NEWGISTICS_API_KEY']
-end

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here is a list of the available configuration options and their default values
 
 | Option          | Description                                                                                                                                                                                                                                                | Default Value                                |
 |-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
-| `host_url`        | The URL of the Newgistics API                                                                                                                                                                                                                              | `"https://apistaging.newgisticsfulfillment.com"` |
+| `api_base_url`        | The URL of the Newgistics API                                                                                                                                                                                                                              | `"https://apistaging.newgisticsfulfillment.com"` |
 | `api_key`         | Your Newgistics API key                                                                                                                                                                                                                                    | `nil`                                          |
 | `time_zone`       | The time zone used by Newgistics. When the API sends timestamps back it doesn't include a time zone, if it's not provided, the value of this setting will be used when parsing the timestamps into `Time` objects. You shouldn't need to change this setting | `"America/Denver"`                               |
 | `local_time_zone` | The time zone used by your application, all Newgistics timestamps will be translated to this time zone automatically.                                                                                                                                      | `"UTC"`                                         |
@@ -35,7 +35,7 @@ To set configuration options use the `Newgistics.configure` method:
 ```ruby
 Newgistics.configure do |config|
   config.api_key = ENV['NEWGISTICS_API_KEY']
-  config.host_url = ENV['NEWGISTIC_API_URL']
+  config.api_base_url = ENV['NEWGISTIC_API_URL']
   config.local_time_zone = "America/New_York"
 end
 ```

--- a/bin/console
+++ b/bin/console
@@ -2,13 +2,15 @@
 
 require "bundler/setup"
 require "newgistics"
-
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require "irb"
+require "pry"
+require "dotenv"
+
+Dotenv.load
+
+Newgistics.configure do |config|
+  config.api_base_url = ENV.fetch('NEWGISTICS_API_URL', "https://apistaging.newgisticsfulfillment.com")
+  config.api_key = ENV['NEWGISTICS_API_KEY']
+end
+
 IRB.start(__FILE__)

--- a/lib/newgistics/api.rb
+++ b/lib/newgistics/api.rb
@@ -13,14 +13,14 @@ module Newgistics
     private
 
     def connection
-      @connection ||= Faraday.new(url: host_url) do |faraday|
+      @connection ||= Faraday.new(url: api_base_url) do |faraday|
         faraday.response :logger, Newgistics.logger, bodies: true
         faraday.adapter Faraday.default_adapter
       end
     end
 
-    def host_url
-      Newgistics.configuration.host_url
+    def api_base_url
+      Newgistics.configuration.api_base_url
     end
   end
 end

--- a/lib/newgistics/configuration.rb
+++ b/lib/newgistics/configuration.rb
@@ -1,15 +1,15 @@
 module Newgistics
   class Configuration
     attr_reader :time_zone, :local_time_zone
-    attr_accessor :api_key, :host_url
+    attr_accessor :api_key, :api_base_url
 
     def initialize
       self.time_zone = "America/Denver"
       self.local_time_zone = "UTC"
     end
 
-    def host_url
-      @host_url ||= "https://apistaging.newgisticsfulfillment.com"
+    def api_base_url
+      @api_base_url ||= "https://apistaging.newgisticsfulfillment.com"
     end
 
     def time_zone=(name)

--- a/spec/support/newgistics.rb
+++ b/spec/support/newgistics.rb
@@ -1,5 +1,5 @@
 Newgistics.configure do |config|
-  config.host_url = "https://apistaging.newgisticsfulfillment.com"
+  config.api_base_url = "https://apistaging.newgisticsfulfillment.com"
 end
 
 Newgistics.logger.level = Logger::FATAL


### PR DESCRIPTION
#### What's this PR do?
With this change we'll rename the host_url configuration setting to api_base_url, we feel like the latter is a better fitting name.

We'll also remove .irbrc and move the initialization code into bin/console so that people can call irb from the project root without any issues.