### PR TITLE
Reduce the number of objects allocated for request processing

### DIFF
--- a/lib/newgistics/string_helper.rb
+++ b/lib/newgistics/string_helper.rb
@@ -1,13 +1,21 @@
 module Newgistics
   class StringHelper
+    CAMEL_CASED_STRING_REGEX = /([a-z])([A-Z])/
+    UNDERSCORED_STRING_REGEX = /([A-Za-z\d]+)(_|\z)/
+    CAPITALIZED_STRING_REGEX = /\A[A-Z]/
+
     def self.camelize(string, upcase_first: true)
-      result = string.to_s.gsub(/([a-z\d]+)(_|\z)/) { $1.capitalize }
-      result = result.gsub(/\A[A-Z]/) { $&.downcase } unless upcase_first
-      result
+      string.dup.to_s.tap do |s|
+        s.gsub!(UNDERSCORED_STRING_REGEX) { $1.capitalize! || $1 }
+        s.gsub!(CAPITALIZED_STRING_REGEX) { $&.downcase! } unless upcase_first
+      end
     end
 
     def self.underscore(string)
-      string.to_s.gsub(/([a-z])([A-Z])/) { "#{$1}_#{$2}" }.downcase
+      string.dup.to_s.tap do |s|
+        s.gsub!(CAMEL_CASED_STRING_REGEX) { "#{$1}_#{$2}" }
+        s.downcase!
+      end
     end
   end
 end

--- a/spec/newgistics/string_helper_spec.rb
+++ b/spec/newgistics/string_helper_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe Newgistics::StringHelper do
+  describe '.camelize' do
+    context "when upcase_first is true" do
+      it "transforms an underscored string as expected" do
+        result = described_class.camelize('a_sample_string', upcase_first: true)
+
+        expect(result).to eq('ASampleString')
+      end
+
+      it "transforms a mixed string as expected" do
+        result = described_class.camelize('a_Sample_String', upcase_first: true)
+
+        expect(result).to eq('ASampleString')
+      end
+    end
+
+    context "when upcase_first is false" do
+      it "transforms an underscored string as expected" do
+        result = described_class.camelize('a_sample_string', upcase_first: false)
+
+        expect(result).to eq('aSampleString')
+      end
+
+      it "transforms a mixed string as expected" do
+        result = described_class.camelize('A_Sample_String', upcase_first: false)
+
+        expect(result).to eq('aSampleString')
+      end
+    end
+  end
+
+  describe '.underscore' do
+    it "transforms a camel-cased string properly" do
+      expect(described_class.underscore('aNiceString')).to eq('a_nice_string')
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
With this change we'll update our `StringHelper` class to perform in-place modifications to strings so we reduce the number of strings allocated when these methods get called.

Sadly, readability will be affected by this change but I believe the positive impact this will have on memory usage is worth it, especially for large requests.

#### Notes
Many of the ideas from this PR were taken from this great article on managing ruby memory:
https://www.sitepoint.com/ruby-uses-memory/