### PR TITLE
Ensure the StringHelper can handle nil and symbol values

### DIFF
--- a/lib/newgistics/string_helper.rb
+++ b/lib/newgistics/string_helper.rb
@@ -5,14 +5,14 @@ module Newgistics
     CAPITALIZED_STRING_REGEX = /\A[A-Z]/
 
     def self.camelize(string, upcase_first: true)
-      string.dup.to_s.tap do |s|
+      string.to_s.dup.tap do |s|
         s.gsub!(UNDERSCORED_STRING_REGEX) { $1.capitalize! || $1 }
         s.gsub!(CAPITALIZED_STRING_REGEX) { $&.downcase! } unless upcase_first
       end
     end
 
     def self.underscore(string)
-      string.dup.to_s.tap do |s|
+      string.to_s.dup.tap do |s|
         s.gsub!(CAMEL_CASED_STRING_REGEX) { "#{$1}_#{$2}" }
         s.downcase!
       end

--- a/spec/newgistics/string_helper_spec.rb
+++ b/spec/newgistics/string_helper_spec.rb
@@ -29,11 +29,19 @@ RSpec.describe Newgistics::StringHelper do
         expect(result).to eq('aSampleString')
       end
     end
+
+    it "can handle nil values" do
+      expect(described_class.camelize(nil)).to eq('')
+    end
   end
 
   describe '.underscore' do
     it "transforms a camel-cased string properly" do
       expect(described_class.underscore('aNiceString')).to eq('a_nice_string')
+    end
+
+    it "can handle nil values" do
+      expect(described_class.underscore(nil)).to eq("")
     end
   end
 end


### PR DESCRIPTION
#### What's this PR do?
With this change we'll make a tiny tweak to the `StringHelper` methods to ensure that nil and symbols can be handled properly.

Until ruby 2.4.0, `nil` and `Symbol` don't respond to `dup` so we'll transform the passed in argument to a `String` first and then `dup` it.