### PR TITLE
Add Shipment Item attributes

### DIFF
--- a/lib/newgistics/item.rb
+++ b/lib/newgistics/item.rb
@@ -5,6 +5,9 @@ module Newgistics
     attribute :id, String
 
     attribute :sku, String
+    attribute :upc, String
+    attribute :description, String
+    attribute :lot, String
     attribute :qty, Integer
     attribute :is_gift_wrapped, Boolean
     attribute :custom_fields, Hash


### PR DESCRIPTION
Enables attributes on Shipment line items:
- UPC
- Description
- Lot