### PR TITLE
Avoid overriding address fields when updating a shipment's address

### DIFF
--- a/lib/newgistics/requests/update_shipment_address.rb
+++ b/lib/newgistics/requests/update_shipment_address.rb
@@ -34,23 +34,28 @@ module Newgistics
 
       def shipment_address_update_xml(xml)
         xml.updateShipment(shipment_address_update_attributes) do
-          xml.FirstName shipment_address_update.first_name
-          xml.LastName shipment_address_update.last_name
-          xml.Company shipment_address_update.company
-          xml.Address1 shipment_address_update.address1
-          xml.Address2 shipment_address_update.address2
-          xml.City shipment_address_update.city
-          xml.State shipment_address_update.state
-          xml.PostalCode shipment_address_update.postal_code
-          xml.Country shipment_address_update.country
-          xml.Email shipment_address_update.email
-          xml.Phone shipment_address_update.phone
-          xml.Fax shipment_address_update.fax
-          xml.IsResidential shipment_address_update.is_residential
-          xml.Status shipment_address_update.status
-          xml.StatusNotes shipment_address_update.status_notes
-          xml.ShipMethod shipment_address_update.ship_method
+          xml_field(xml, 'FirstName', :first_name)
+          xml_field(xml, 'LastName', :last_name)
+          xml_field(xml, 'Company', :company)
+          xml_field(xml, 'Address1', :address1)
+          xml_field(xml, 'Address2', :address2)
+          xml_field(xml, 'City', :city)
+          xml_field(xml, 'State', :state)
+          xml_field(xml, 'PostalCode', :postal_code)
+          xml_field(xml, 'Country', :country)
+          xml_field(xml, 'Email', :email)
+          xml_field(xml, 'Phone', :phone)
+          xml_field(xml, 'Fax', :fax)
+          xml_field(xml, 'IsResidential', :is_residential)
+          xml_field(xml, 'Status', :status)
+          xml_field(xml, 'StatusNotes', :status_notes)
+          xml_field(xml, 'ShipMethod', :ship_method)
         end
+      end
+
+      def xml_field(xml, xml_node, attribute_name)
+        value = shipment_address_update.send(attribute_name)
+        xml.send(xml_node, value) unless value.nil?
       end
 
       def api_key

--- a/spec/newgistics/requests/update_shipment_address_spec.rb
+++ b/spec/newgistics/requests/update_shipment_address_spec.rb
@@ -51,4 +51,19 @@ RSpec.describe Newgistics::Requests::UpdateShipmentAddress do
       expect(update).to have_element('StatusNotes').with_text('Some notes')
     end
   end
+
+  it "doesn't serialize nil attributes" do
+    address_update = Newgistics::ShipmentAddressUpdate.new(
+      status: 'ONHOLD',
+      address1: nil,
+      address2: ''
+    )
+    request = described_class.new(address_update)
+
+    xml = Nokogiri::XML(request.body).at_css('updateShipment')
+
+    expect(xml).not_to have_element('Address1')
+    expect(xml).to have_element('Address2').with_text('')
+    expect(xml).to have_element('Status').with_text('ONHOLD')
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
With this change we'll prevent developers from accidentally overriding unwanted fields on a shipment when performing an address update.

Basically, if we only set the `:status` attribute in a `Newgistics::ShipmentAddressUpdate`, then that should be the only field that gets updated in Newgistics, previously we were including nil attributes in the request and Newgistics was setting those fields to nil, which is not what we want.