### PR TITLE
Add support for the Reference1 and Reference2 fields

### DIFF
--- a/lib/newgistics/order.rb
+++ b/lib/newgistics/order.rb
@@ -18,6 +18,8 @@ module Newgistics
     attribute :custom_fields, Hash
     attribute :allow_duplicate, Boolean
     attribute :items, Array[Item]
+    attribute :reference_1, String
+    attribute :reference_2, String
 
     attribute :errors, Array[String], default: []
     attribute :warnings, Array[String], default: []

--- a/lib/newgistics/requests/post_shipment.rb
+++ b/lib/newgistics/requests/post_shipment.rb
@@ -54,6 +54,8 @@ module Newgistics
           xml.GiftMessage order.gift_message
           xml.HoldForAllInventory order.hold_for_all_inventory
           xml.AllowDuplicate order.allow_duplicate
+          xml.Reference1 order.reference_1
+          xml.Reference2 order.reference_2
 
           order_date_xml(order, xml)
           customer_xml(order.customer, xml)

--- a/newgistics.gemspec
+++ b/newgistics.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "vcr", "~> 3.0.3"
   spec.add_development_dependency "timecop", "~> 0.9"

--- a/spec/newgistics/requests/post_shipment_spec.rb
+++ b/spec/newgistics/requests/post_shipment_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Newgistics::Requests::PostShipment do
         hold_for_all_inventory: true,
         allow_duplicate: false,
         order_date: '2017-08-20',
+        reference_1: 'Reference 1',
+        reference_2: 'Reference 2',
         customer: {
           first_name: 'Stephen',
           last_name: 'Strange',
@@ -86,6 +88,8 @@ RSpec.describe Newgistics::Requests::PostShipment do
       expect(order_xml).to have_element('HoldForAllInventory').with_text('true')
       expect(order_xml).to have_element('OrderDate').with_text('08/20/2017')
       expect(order_xml).to have_element('AllowDuplicate').with_text('false')
+      expect(order_xml).to have_element('Reference1').with_text('Reference 1')
+      expect(order_xml).to have_element('Reference2').with_text('Reference 2')
     end
 
     def verify_customer_xml(customer_xml)


### PR DESCRIPTION
#### What's this PR do?
With this change we'll add a couple of new attributes to the Order model so we can include the `Reference1` and `Reference2` fields when submitting orders to Newgistics.